### PR TITLE
Implement staff management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,13 @@
 +- `script.js` – game logic including purchases, feeding, harvesting and UI updates.
 +- `style.css` – minimal styling for layout and components.
 +
++## Staff System
++Sites now support hiring staff members who perform automated tasks. Available roles are:
++
++- **Feeder Loader** – automatically feeds all pens each second.
++- **Silo Refill** – automatically buys feed when the barge has space.
++- **Maintenance** – reserved for future automation tasks.
++- **Mortality Collector** – reserved for future features.
++
++Use the new Staff card on the main screen to hire employees, change their role or fire them. Staff count is limited by each barge's `staffCapacity`.
 +Feel free to modify `script.js` or the data structures within it to tweak starting values, species parameters or upgrade costs.

--- a/index.html
+++ b/index.html
@@ -54,6 +54,20 @@
       <div>Staff Capacity: <span id="bargeStaffCapacity">0</span></div>
     </div>
 
+    <div id="staffCard" class="staffCard">
+      <h2>Staff</h2>
+      <div id="staffList"></div>
+      <div class="hireControls">
+        <select id="hireRole">
+          <option value="Feeder Loader">Feeder Loader</option>
+          <option value="Silo Refill">Silo Refill</option>
+          <option value="Maintenance">Maintenance</option>
+          <option value="Mortality Collector">Mortality Collector</option>
+        </select>
+        <button onclick="hireStaff()">Hire</button>
+      </div>
+    </div>
+
     <!-- Harvest info (single-pen harvest preview) -->
     <div id="harvestInfo" class="harvestInfo"></div>
 

--- a/style.css
+++ b/style.css
@@ -213,6 +213,32 @@ button:active {
   font-size: 14px;
   margin: 6px 0;
 }
+
+.staffCard {
+  background: #1f2d35;
+  border-radius: 10px;
+  padding: 16px;
+  margin: 16px auto;
+  color: #dbe5ed;
+  box-shadow: 0 0 4px #0005;
+  max-width: 300px;
+}
+.staffCard h2 {
+  font-size: 18px;
+  margin-bottom: 10px;
+  color: #4be0ff;
+}
+.staffRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 4px 0;
+  font-size: 14px;
+}
+.hireControls select {
+  padding: 4px 6px;
+  margin-right: 6px;
+}
 #topBar {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add staff list and hire controls
- track staff on sites
- automate feeder loading and silo refills
- style the new UI panel
- document the staff system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876bde5fbc483298de0d735474ad97f