### PR TITLE
Fix mobile layout and hide sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="toggleSidebar">☰</button>
   <div id="sidebar">
-    <button id="toggleSidebar">☰</button>
     <div id="sidebarContent">
       <button id="toggleShop" onclick="togglePanel('shop')">&#128722;</button>
       <button id="toggleDevMenu" onclick="togglePanel('devMenu')">🛠</button>

--- a/style.css
+++ b/style.css
@@ -5,6 +5,7 @@ body {
   color: #dbe5ed;
   text-align: center;
   margin-top: 30px;
+  overflow-x: hidden; /* prevent horizontal scroll on mobile */
 }
 .container {
   max-width: 900px;
@@ -38,7 +39,7 @@ button:active {
   height: 100%;
   width: 60px;
   background: #142027;
-  transition: width 0.3s;
+  transition: width 0.3s, transform 0.3s;
   overflow: hidden;
   z-index: 10;
 }
@@ -46,13 +47,22 @@ button:active {
   width: 200px;
 }
 #toggleSidebar {
-  width: 100%;
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  width: 48px;
+  height: 48px;
   background: #1a272e;
   border: none;
   color: #8899a6;
   font-size: 24px;
   cursor: pointer;
-  padding: 10px 0;
+  border-radius: 8px;
+  z-index: 20;
+  transition: background-color 0.3s;
+}
+#toggleSidebar:hover {
+  background-color: #1f2d35;
 }
 #sidebarContent {
   overflow-y: auto;
@@ -245,4 +255,15 @@ button:active {
 .top-left button:hover, .top-right button:hover {
   background-color: #4be0ff;
   color: #142027;
+}
+
+/* Mobile sidebar behavior */
+@media (max-width: 700px) {
+  #sidebar {
+    transform: translateX(-100%);
+    width: 200px;
+  }
+  #sidebar.open {
+    transform: translateX(0);
+  }
 }


### PR DESCRIPTION
## Summary
- move sidebar toggle button outside sidebar container
- adjust sidebar and toggle button styling
- hide sidebar by default on small screens
- prevent horizontal scrolling on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a20e307c083298a6a5a9d1bbb2f05