### PR TITLE
Improve mobile sidebar behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Aquaculture Empire</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="toggleSidebar">☰</button>
   <div id="sidebar">
-    <button id="toggleSidebar">☰</button>
     <div id="sidebarContent">
       <button id="toggleShop" onclick="togglePanel('shop')">&#128722;</button>
       <button id="toggleDevMenu" onclick="togglePanel('devMenu')">🛠</button>

--- a/script.js
+++ b/script.js
@@ -299,8 +299,10 @@ function togglePanel(id){
   document.getElementById('toggle'+capitalizeFirstLetter(id)).classList.add('active');
 }
 document.getElementById('toggleSidebar').addEventListener('click',()=>{
-  document.getElementById('sidebar').classList.toggle('open');
-  if(!document.getElementById('sidebar').classList.contains('open')){
+  const sidebar = document.getElementById('sidebar');
+  sidebar.classList.toggle('open');
+  document.body.classList.toggle('sidebar-open', sidebar.classList.contains('open'));
+  if(!sidebar.classList.contains('open')){
     document.querySelectorAll('#sidebar .panel').forEach(x=>x.classList.remove('visible'));
     document.querySelectorAll('#sidebarContent button').forEach(x=>x.classList.remove('active'));
   }

--- a/style.css
+++ b/style.css
@@ -5,11 +5,13 @@ body {
   color: #dbe5ed;
   text-align: center;
   margin-top: 30px;
+  overflow-x: hidden; /* prevent horizontal scroll on mobile */
 }
 .container {
   max-width: 900px;
   margin: 0 auto;
   padding: 0 20px;
+  transition: transform 0.3s;
 }
 button {
   margin: 8px;
@@ -38,7 +40,7 @@ button:active {
   height: 100%;
   width: 60px;
   background: #142027;
-  transition: width 0.3s;
+  transition: width 0.3s, transform 0.3s;
   overflow: hidden;
   z-index: 10;
 }
@@ -46,13 +48,22 @@ button:active {
   width: 200px;
 }
 #toggleSidebar {
-  width: 100%;
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  width: 48px;
+  height: 48px;
   background: #1a272e;
   border: none;
   color: #8899a6;
   font-size: 24px;
   cursor: pointer;
-  padding: 10px 0;
+  border-radius: 8px;
+  z-index: 20;
+  transition: background-color 0.3s;
+}
+#toggleSidebar:hover {
+  background-color: #1f2d35;
 }
 #sidebarContent {
   overflow-y: auto;
@@ -245,4 +256,30 @@ button:active {
 .top-left button:hover, .top-right button:hover {
   background-color: #4be0ff;
   color: #142027;
+}
+
+/* Mobile sidebar behavior */
+@media (max-width: 700px) {
+  #sidebar {
+    transform: translateX(-100%);
+    width: 200px;
+  }
+  #sidebar.open {
+    transform: translateX(0);
+  }
+  body.sidebar-open .container {
+    transform: translateX(200px);
+  }
+  body {
+    font-size: 17px;
+  }
+  button {
+    font-size: 17px;
+  }
+  .penCard h3 {
+    font-size: 20px;
+  }
+  .penCard .stat, .bargeCard div {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper mobile scaling
- slide content to the right when sidebar is open on phones
- enlarge fonts on small screens for readability
- toggle class on body to control layout shift

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a20e307c083298a6a5a9d1bbb2f05