### PR TITLE
Add tiered feeder upgrades per pen

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Aquaculture Empire is a small browser-based aquaculture management game written 
 - Side panel shop to buy additional feed, upgrade storage and acquire new pens.
 - Purchase licenses to farm new species such as shrimp, salmon and tuna.
 - Harvest pens for cash, restock them and upgrade automatic feeders.
+- Each pen has a tiered auto-feeder path from floating rafts to
+  underwater systems with individual upgrade costs.
 - Expand your business by buying entirely new sites.
 - Development menu with a helper button to add cash instantly.
 


### PR DESCRIPTION
## Summary
- add `feederUpgrades` data describing floating, spreader and underwater units
- display next feeder upgrade cost in each pen card
- upgrade feeders per pen with associated cost
- adjust feeder rate lookup
- document tiered feeder system in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a2cf3a8248329ab7e228ddecddcff