### PR TITLE
Modularize data and site objects

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,0 +1,45 @@
+export const bargeTiers = [
+  { name: 'Small',  feedCapacity: 200, feederLimit: 2, maxFeederTier: 1, cost: 0 },
+  { name: 'Medium', feedCapacity: 500, feederLimit: 4, maxFeederTier: 2, cost: 5000 },
+  { name: 'Large',  feedCapacity: 1000, feederLimit: 8, maxFeederTier: 3, cost: 15000 }
+];
+
+export const NEW_BARGE_COST = 8000;
+
+export const feedStorageUpgrades = [
+  { capacity: 250, cost: 100 }, { capacity: 500, cost: 250 },
+  { capacity: 1000, cost: 500 }, { capacity: 2000, cost: 1000 },
+  { capacity: 5000, cost: 2500 }, { capacity: 10000, cost: 6000 },
+  { capacity: 20000, cost: 12000 }, { capacity: 30000, cost: 20000 }
+];
+
+export const STAFF_HIRE_COST = 500;
+
+export const staffRoles = {
+  feeder:    { cost: 500,  description: 'Boosts auto feed rate' },
+  harvester: { cost: 800,  description: 'Increases harvest capacity' },
+  feedManager:{ cost: 1000, description: 'Automatically buys feed' }
+};
+
+export const staffHousingUpgrades = [
+  { extraCapacity: 2, cost: 1000 },
+  { extraCapacity: 2, cost: 2000 },
+  { extraCapacity: 4, cost: 4000 }
+];
+
+export const speciesData = {
+  shrimp: { marketPrice:8, fcr:1.25, startingWeight:0.01, restockCount:500, restockCost:200, licenseCost:0 },
+  salmon: { marketPrice:5, fcr:1.5, startingWeight:0.05, restockCount:250, restockCost:400, licenseCost:500 },
+  tuna:   { marketPrice:10,fcr:2.0, startingWeight:0.2,  restockCount:100, restockCost:800, licenseCost:1500 }
+};
+
+export const feederUpgrades = [
+  { type: 'floating',   rate: 1, cost: 500  },
+  { type: 'spreader',   rate: 2, cost: 1200 },
+  { type: 'underwater', rate: 3, cost: 2500 }
+];
+
+export const siteNamePrefixes = [
+  'Driftwood','Stormreach','Gullrock','Cedar','Misty','Haven','Breakwater','Whispering','Duskwater','Salmonstone','SeaLion'
+];
+export const siteNameSuffixes = ['Sound','Inlet','Bay','Island','Channel','Passage','Lagoon','Rock'];

--- a/index.html
+++ b/index.html
@@ -100,6 +100,6 @@
     </div>
   </div>
 
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/models.js
+++ b/models.js
@@ -1,0 +1,57 @@
+export class Barge {
+  constructor({
+    feed = 100,
+    feedCapacity,
+    siloCapacity = 1000,
+    staffCapacity = 2,
+    tier = 0,
+    feederLimit,
+    maxFeederTier,
+    upgrades = [],
+    storageUpgradeLevel = 0,
+    housingUpgradeLevel = 0
+  } = {}) {
+    this.feed = feed;
+    this.feedCapacity = feedCapacity;
+    this.siloCapacity = siloCapacity;
+    this.staffCapacity = staffCapacity;
+    this.tier = tier;
+    this.feederLimit = feederLimit;
+    this.maxFeederTier = maxFeederTier;
+    this.upgrades = upgrades;
+    this.storageUpgradeLevel = storageUpgradeLevel;
+    this.housingUpgradeLevel = housingUpgradeLevel;
+  }
+}
+
+export class Pen {
+  constructor({
+    species = 'shrimp',
+    fishCount = 0,
+    averageWeight = 0,
+    bargeIndex = 0,
+    feeder = null
+  } = {}) {
+    this.species = species;
+    this.fishCount = fishCount;
+    this.averageWeight = averageWeight;
+    this.bargeIndex = bargeIndex;
+    this.feeder = feeder;
+  }
+}
+
+export class Site {
+  constructor({
+    name,
+    barges = [],
+    staff = [],
+    licenses = [],
+    pens = []
+  } = {}) {
+    this.name = name;
+    this.barges = barges;
+    this.staff = staff;
+    this.licenses = licenses;
+    this.pens = pens;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,3 +1,17 @@
+import {
+  bargeTiers,
+  NEW_BARGE_COST,
+  feedStorageUpgrades,
+  STAFF_HIRE_COST,
+  staffRoles,
+  staffHousingUpgrades,
+  speciesData,
+  feederUpgrades,
+  siteNamePrefixes,
+  siteNameSuffixes
+} from './data.js';
+import { Site, Barge, Pen } from './models.js';
+
 // Core Game State
 let cash = 200;
 const BASE_HARVEST_CAPACITY = 50;
@@ -16,20 +30,12 @@ function addStatusMessage(msg){
   if(el) el.innerText = msg;
 }
 
-// Barge tiers
-const bargeTiers = [
-  { name: 'Small',  feedCapacity: 200, feederLimit: 2, maxFeederTier: 1, cost: 0 },
-  { name: 'Medium', feedCapacity: 500, feederLimit: 4, maxFeederTier: 2, cost: 5000 },
-  { name: 'Large',  feedCapacity: 1000, feederLimit: 8, maxFeederTier: 3, cost: 15000 }
-];
-const NEW_BARGE_COST = 8000;
-
 // Game Data
 let sites = [
-  {
-    name: "Mernan Inlet",
+  new Site({
+    name: 'Mernan Inlet',
     barges: [
-      {
+      new Barge({
         feed: 100,
         feedCapacity: bargeTiers[0].feedCapacity,
         siloCapacity: 1000,
@@ -40,48 +46,17 @@ let sites = [
         upgrades: [],
         storageUpgradeLevel: 0,
         housingUpgradeLevel: 0
-      }
+      })
     ],
     staff: [],
     licenses: ['shrimp'],
     pens: [
-      { species: "shrimp", fishCount: 500, averageWeight: 0.01, bargeIndex: 0 }
+      new Pen({ species: 'shrimp', fishCount: 500, averageWeight: 0.01, bargeIndex: 0 })
     ]
-  }
+  })
 ];
 
-// Upgrades & Species
-const feedStorageUpgrades = [
-  { capacity: 250, cost: 100 }, { capacity: 500, cost: 250 },
-  { capacity: 1000, cost: 500 }, { capacity: 2000, cost: 1000 },
-  { capacity: 5000, cost: 2500 }, { capacity: 10000, cost: 6000 },
-  { capacity: 20000, cost: 12000 }, { capacity: 30000, cost: 20000 }
-];
-const STAFF_HIRE_COST = 500;
-const staffRoles = {
-  feeder:    { cost: 500,  description: 'Boosts auto feed rate' },
-  harvester: { cost: 800,  description: 'Increases harvest capacity' },
-  feedManager:{ cost: 1000, description: 'Automatically buys feed' }
-};
-const staffHousingUpgrades = [
-  { extraCapacity: 2, cost: 1000 },
-  { extraCapacity: 2, cost: 2000 },
-  { extraCapacity: 4, cost: 4000 }
-];
-const speciesData = {
-  shrimp: { marketPrice:8, fcr:1.25, startingWeight:0.01, restockCount:500, restockCost:200, licenseCost:0 },
-  salmon: { marketPrice:5, fcr:1.5, startingWeight:0.05, restockCount:250, restockCost:400, licenseCost:500 },
-  tuna:   { marketPrice:10,fcr:2.0, startingWeight:0.2,  restockCount:100, restockCost:800, licenseCost:1500 }
-};
-
-// Auto feeder upgrade tiers
-const feederUpgrades = [
-  { type: 'floating',   rate: 1, cost: 500  }, // manual floating feeder
-  { type: 'spreader',   rate: 2, cost: 1200 }, // air-assisted spreader
-  { type: 'underwater', rate: 3, cost: 2500 }  // submersible feeder
-];
-const siteNamePrefixes = ["Driftwood","Stormreach","Gullrock","Cedar","Misty","Haven","Breakwater","Whispering","Duskwater","Salmonstone","SeaLion"];
-const siteNameSuffixes = ["Sound","Inlet","Bay","Island","Channel","Passage","Lagoon","Rock"];
+// Upgrades & Species constants are imported from data.js
 
 // UTILITIES
 function capitalizeFirstLetter(str){ return str.charAt(0).toUpperCase()+str.slice(1); }
@@ -536,6 +511,37 @@ function nextSite(){ if(currentSiteIndex<sites.length-1) currentSiteIndex++; cur
 
 function previousBarge(){ if(currentBargeIndex>0) currentBargeIndex--; updateDisplay(); }
 function nextBarge(){ const site = sites[currentSiteIndex]; if(currentBargeIndex<site.barges.length-1) currentBargeIndex++; updateDisplay(); }
+
+// Expose functions for HTML event handlers
+Object.assign(window, {
+  buyFeed,
+  buyMaxFeed,
+  buyFeedStorageUpgrade,
+  buyLicense,
+  buyNewSite,
+  buyNewPen,
+  buyNewBarge,
+  hireStaff,
+  assignStaff,
+  unassignStaff,
+  upgradeStaffHousing,
+  upgradeBarge,
+  addDevCash,
+  togglePanel,
+  openModal,
+  closeModal,
+  openRestockModal,
+  closeRestockModal,
+  feedFishPen,
+  harvestPenIndex,
+  restockPenUI,
+  upgradeFeeder,
+  assignBarge,
+  previousSite,
+  nextSite,
+  previousBarge,
+  nextBarge
+});
 
 // Initialize
 document.addEventListener("DOMContentLoaded",()=>updateDisplay());


### PR DESCRIPTION
## Summary
- add `models.js` with Barge, Pen and Site classes
- move configuration constants into `data.js`
- load `script.js` as an ES module and create the default site using classes
- expose functions for HTML handlers

## Testing
- `node --check script.js`
- `node --check data.js`


------
https://chatgpt.com/codex/tasks/task_e_687a34bdd2a88329be6efa49059730a3