### PR TITLE
Add staff management card

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,6 @@
         <button onclick="buyNewBarge()">Buy Barge</button>
         <button onclick="upgradeBarge()">Upgrade Barge</button>
         <button onclick="buyNewPen()">+ Pen</button>
-        <button onclick="hireStaff()">Hire Staff ($500)</button>
-        <button onclick="assignStaff('feeder')">Assign Feeder</button>
-        <button onclick="assignStaff('harvester')">Assign Harvester</button>
-        <button onclick="assignStaff('feedManager')">Assign Feed Manager</button>
-        <button onclick="unassignStaff('feedManager')">Unassign Feed Manager</button>
-        <button onclick="upgradeStaffHousing()">Upgrade Housing</button>
         <div id="storageUpgradeInfo"></div>
         <div id="housingUpgradeInfo"></div>
         <div id="bargeUpgradeInfo"></div>
@@ -61,20 +55,39 @@
     </div>
 
 
-    <!-- Barge card -->
-    <div id="bargeCard" class="bargeCard">
-      <h2>Barge Status</h2>
-      <div>
-        <button onclick="previousBarge()">⟵</button>
-        Barge <span id="bargeIndex">1</span>/<span id="bargeCount">1</span>
-        <button onclick="nextBarge()">⟶</button>
+    <!-- Status cards -->
+    <div id="cardContainer" class="cardContainer">
+      <div id="bargeCard" class="bargeCard">
+        <h2>Barge Status</h2>
+        <div>
+          <button onclick="previousBarge()">⟵</button>
+          Barge <span id="bargeIndex">1</span>/<span id="bargeCount">1</span>
+          <button onclick="nextBarge()">⟶</button>
+        </div>
+        <div>Barge Tier: <span id="bargeTierName">Small</span></div>
+        <div>Feeders: <span id="bargeFeedersUsed">0</span>/<span id="bargeFeederLimit">0</span> (Max Tier <span id="bargeMaxFeederTier">0</span>)</div>
+        <div>Feed: <span id="bargeFeed">0</span> / <span id="bargeFeedCapacity">0</span> kg</div>
+        <div>Silo Capacity: <span id="bargeSiloCapacity">0</span> kg</div>
+        <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
+        <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
       </div>
-      <div>Barge Tier: <span id="bargeTierName">Small</span></div>
-      <div>Feeders: <span id="bargeFeedersUsed">0</span>/<span id="bargeFeederLimit">0</span> (Max Tier <span id="bargeMaxFeederTier">0</span>)</div>
-      <div>Feed: <span id="bargeFeed">0</span> / <span id="bargeFeedCapacity">0</span> kg</div>
-      <div>Silo Capacity: <span id="bargeSiloCapacity">0</span> kg</div>
-      <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
-      <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
+      <div id="staffCard" class="staffCard">
+        <h2>Staffing</h2>
+        <div>Total: <span id="staffTotal">0</span> / <span id="staffCapacity">0</span></div>
+        <div>Unassigned: <span id="staffUnassigned">0</span></div>
+        <div>Feeders: <span id="staffFeeders">0</span></div>
+        <div>Harvesters: <span id="staffHarvesters">0</span></div>
+        <div>Feed Managers: <span id="staffManagers">0</span></div>
+        <button onclick="hireStaff()">Hire Staff ($500)</button>
+        <button onclick="fireStaff()">Fire Unassigned</button>
+        <button onclick="assignStaff('feeder')">Assign Feeder</button>
+        <button onclick="unassignStaff('feeder')">Remove Feeder</button>
+        <button onclick="assignStaff('harvester')">Assign Harvester</button>
+        <button onclick="unassignStaff('harvester')">Remove Harvester</button>
+        <button onclick="assignStaff('feedManager')">Assign Feed Manager</button>
+        <button onclick="unassignStaff('feedManager')">Remove Feed Manager</button>
+        <button onclick="upgradeStaffHousing()">Upgrade Housing</button>
+      </div>
     </div>
 
     <!-- Harvest info (single-pen harvest preview) -->

--- a/script.js
+++ b/script.js
@@ -93,6 +93,14 @@ function updateDisplay(){
   document.getElementById('bargeStaffCapacity').innerText = totalCapacity;
   document.getElementById('bargeStaffUnassigned').innerText = site.staff.filter(s=>!s.role).length;
 
+  // staff card info
+  document.getElementById('staffTotal').innerText = site.staff.length;
+  document.getElementById('staffCapacity').innerText = totalCapacity;
+  document.getElementById('staffUnassigned').innerText = site.staff.filter(s=>!s.role).length;
+  document.getElementById('staffFeeders').innerText = site.staff.filter(s=>s.role==='feeder').length;
+  document.getElementById('staffHarvesters').innerText = site.staff.filter(s=>s.role==='harvester').length;
+  document.getElementById('staffManagers').innerText = site.staff.filter(s=>s.role==='feedManager').length;
+
   // shop panel info
   if(barge.storageUpgradeLevel < feedStorageUpgrades.length){
     document.getElementById('storageUpgradeInfo').innerText =
@@ -299,6 +307,13 @@ function hireStaff(){
   if(cash < STAFF_HIRE_COST) return openModal("Not enough cash to hire staff.");
   cash -= STAFF_HIRE_COST;
   site.staff.push({ role: null });
+  updateDisplay();
+}
+function fireStaff(role=null){
+  const site = sites[currentSiteIndex];
+  const idx = site.staff.findIndex(s => role ? s.role===role : !s.role);
+  if(idx === -1) return openModal("No staff member available to fire.");
+  site.staff.splice(idx,1);
   updateDisplay();
 }
 function assignStaff(role){
@@ -558,6 +573,7 @@ Object.assign(window, {
   buyNewPen,
   buyNewBarge,
   hireStaff,
+  fireStaff,
   assignStaff,
   unassignStaff,
   upgradeStaffHousing,

--- a/style.css
+++ b/style.css
@@ -229,6 +229,21 @@ button:active {
   box-shadow: 0 0 4px #0005;
   max-width: 300px;
 }
+.staffCard {
+  background: #1f2d35;
+  border-radius: 10px;
+  padding: 16px;
+  margin: 16px auto;
+  color: #dbe5ed;
+  box-shadow: 0 0 4px #0005;
+  max-width: 300px;
+}
+.cardContainer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+}
 .bargeCard h2 {
   font-size: 18px;
   margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- add `staffCard` next to `bargeCard`
- move hiring and job assignment buttons into new card
- implement `fireStaff` helper and expose it for UI
- display staff stats in the new card
- layout card container styles

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_687a46342fb88329b5ef691024d7d099