### PR TITLE
Add market selling system

### DIFF
--- a/data.js
+++ b/data.js
@@ -49,3 +49,16 @@ export const siteNamePrefixes = [
   'Driftwood','Stormreach','Gullrock','Cedar','Misty','Haven','Breakwater','Whispering','Duskwater','Salmonstone','SeaLion'
 ];
 export const siteNameSuffixes = ['Sound','Inlet','Bay','Island','Channel','Passage','Lagoon','Rock'];
+
+export const markets = [
+  {
+    name: 'Capital Wharf',
+    location: { x: 0, y: 0 },
+    modifiers: { shrimp: 1.0, salmon: 1.1, tuna: 0.9 }
+  },
+  {
+    name: 'East Bay Processing',
+    location: { x: 80, y: 60 },
+    modifiers: { shrimp: 1.2, salmon: 0.9, tuna: 1.1 }
+  }
+];

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
         <div>Location: <span id="vesselLocation">Dock</span></div>
         <button onclick="upgradeVessel()">Upgrade Vessel</button>
         <div id="vesselUpgradeInfo"></div>
+        <button onclick="openSellModal()">Sell Cargo</button>
       </div>
       <div id="staffCard" class="staffCard">
         <h2>Staffing</h2>
@@ -134,6 +135,13 @@
         <input type="number" id="harvestAmount" min="0" step="0.1">
         <button onclick="confirmHarvest()">Harvest</button>
         <button onclick="closeHarvestModal()">Cancel</button>
+      </div>
+    </div>
+    <div id="sellModal">
+      <div id="sellModalContent">
+        <h2>Select Market</h2>
+        <div id="sellOptions"></div>
+        <button onclick="closeSellModal()">Cancel</button>
       </div>
     </div>
   </div>

--- a/models.js
+++ b/models.js
@@ -43,12 +43,14 @@ export class Pen {
 export class Site {
   constructor({
     name,
+    location = { x: 0, y: 0 },
     barges = [],
     staff = [],
     licenses = [],
     pens = []
   } = {}) {
     this.name = name;
+    this.location = location;
     this.barges = barges;
     this.staff = staff;
     this.licenses = licenses;
@@ -61,6 +63,7 @@ export class Vessel {
     name,
     maxBiomassCapacity = 1000,
     currentBiomassLoad = 0,
+    cargo = {},
     speed = 10,
     location = '',
     tier = 0
@@ -68,6 +71,7 @@ export class Vessel {
     this.name = name;
     this.maxBiomassCapacity = maxBiomassCapacity;
     this.currentBiomassLoad = currentBiomassLoad;
+    this.cargo = cargo;
     this.speed = speed;
     this.location = location;
     this.tier = tier;

--- a/style.css
+++ b/style.css
@@ -137,7 +137,8 @@ button:active {
 /* ===== MODAL OVERLAY ===== */
 #modal,
 #restockModal,
-#harvestModal {
+#harvestModal,
+#sellModal {
   position: fixed;
   top: 0;
   left: 0;
@@ -152,13 +153,15 @@ button:active {
 
 #modal.visible,
 #restockModal.visible,
-#harvestModal.visible {
+#harvestModal.visible,
+#sellModal.visible {
   display: flex;
 }
 
 #modalContent,
 #restockModalContent,
-#harvestModalContent {
+#harvestModalContent,
+#sellModalContent {
   background: #293745;
   color: #dbe5ed;
   padding: 20px;


### PR DESCRIPTION
## Summary
- add markets with unique pricing
- implement vessel cargo selling with travel time
- track site and vessel locations
- add UI components for selling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a4f51042083299d67ddbf8dc23190