### PR TITLE
Add icons, tooltips and shoreline to map

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,10 @@
       </div>
       <div id="map" class="panel">
         <h2>Map</h2>
-        <canvas id="mapCanvas" width="400" height="300"></canvas>
+        <div id="mapContainer">
+          <canvas id="mapCanvas" width="400" height="300"></canvas>
+          <div id="mapTooltip"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -230,6 +230,22 @@ button:active {
   margin-top: 10px;
   border-radius: 8px;
 }
+#mapContainer {
+  position: relative;
+  display: inline-block;
+}
+#mapTooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.9);
+  color: #000;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  white-space: nowrap;
+  display: none;
+  z-index: 5;
+}
 #feedPurchaseButtons button {
   display: inline-block;
 }


### PR DESCRIPTION
## Summary
- wrap map canvas with container and tooltip div
- style tooltip overlay
- draw map with emoji icons and wavy coastline
- add tooltip interactions for mouse and touch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a59387c5c832988c7629f5cccefe6