### PR TITLE
Add collapsible shop sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,37 @@
           <button onclick="buyFeed(100)">+100kg Feed</button>
           <button onclick="buyMaxFeed()">Buy Max</button>
         </div>
-        <button onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
-        <button onclick="buyNewBarge()">Buy Barge</button>
-        <button onclick="upgradeBarge()">Upgrade Barge</button>
-        <button onclick="buyNewPen()">+ Pen</button>
+
+        <div class="shopSection" onclick="toggleSection('bargeOptions')">Barge Upgrades</div>
+        <div id="bargeOptions" class="shopSection-content">
+          <button onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
+          <button onclick="buyNewBarge()">Buy Barge</button>
+          <button onclick="upgradeBarge()">Upgrade Barge</button>
+          <button onclick="buyNewPen()">+ Pen</button>
+        </div>
+
+        <div class="shopSection" onclick="toggleSection('staffOptions')">Staff</div>
+        <div id="staffOptions" class="shopSection-content">
+          <button onclick="hireStaff()">Hire Staff ($500)</button>
+          <button onclick="fireStaff()">Fire Unassigned</button>
+          <button onclick="assignStaff('feeder')">Assign Feeder</button>
+          <button onclick="unassignStaff('feeder')">Remove Feeder</button>
+          <button onclick="assignStaff('harvester')">Assign Harvester</button>
+          <button onclick="unassignStaff('harvester')">Remove Harvester</button>
+          <button onclick="assignStaff('feedManager')">Assign Feed Manager</button>
+          <button onclick="unassignStaff('feedManager')">Remove Feed Manager</button>
+          <button onclick="upgradeStaffHousing()">Upgrade Housing</button>
+        </div>
+
+        <div class="shopSection" onclick="toggleSection('vesselOptions')">Vessels</div>
+        <div id="vesselOptions" class="shopSection-content">
+          <button onclick="renameVessel()">Rename Vessel</button>
+          <button onclick="upgradeVessel()">Upgrade Vessel</button>
+          <button onclick="buyNewVessel()">Buy Vessel</button>
+          <button onclick="openMoveVesselModal()">Move Vessel</button>
+          <button onclick="openSellModal()">Sell Cargo</button>
+        </div>
+
         <div id="storageUpgradeInfo"></div>
         <div id="housingUpgradeInfo"></div>
         <div id="bargeUpgradeInfo"></div>
@@ -90,13 +117,9 @@
         <div>Tier: <span id="vesselTierName">Small</span></div>
         <div>Load: <span id="vesselLoad">0</span> / <span id="vesselCapacity">0</span> kg</div>
         <div>Location: <span id="vesselLocation">Dock</span></div>
-        <button onclick="renameVessel()">Rename Vessel</button>
-        <button onclick="upgradeVessel()">Upgrade Vessel</button>
         <div id="vesselUpgradeInfo"></div>
         <div id="vesselPurchaseInfo"></div>
-        <button onclick="buyNewVessel()">Buy Vessel</button>
-        <button onclick="openMoveVesselModal()">Move Vessel</button>
-        <button onclick="openSellModal()">Sell Cargo</button>
+        <div id="vesselActionPlaceholder"></div>
       </div>
       <div id="staffCard" class="staffCard">
         <h2>Staffing</h2>
@@ -105,15 +128,7 @@
         <div>Feeders: <span id="staffFeeders">0</span></div>
         <div>Harvesters: <span id="staffHarvesters">0</span></div>
         <div>Feed Managers: <span id="staffManagers">0</span></div>
-        <button onclick="hireStaff()">Hire Staff ($500)</button>
-        <button onclick="fireStaff()">Fire Unassigned</button>
-        <button onclick="assignStaff('feeder')">Assign Feeder</button>
-        <button onclick="unassignStaff('feeder')">Remove Feeder</button>
-        <button onclick="assignStaff('harvester')">Assign Harvester</button>
-        <button onclick="unassignStaff('harvester')">Remove Harvester</button>
-        <button onclick="assignStaff('feedManager')">Assign Feed Manager</button>
-        <button onclick="unassignStaff('feedManager')">Remove Feed Manager</button>
-        <button onclick="upgradeStaffHousing()">Upgrade Housing</button>
+        <div id="staffActionPlaceholder"></div>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -821,6 +821,11 @@ document.getElementById('toggleSidebar').addEventListener('click',()=>{
   }
 });
 
+function toggleSection(id){
+  const el = document.getElementById(id);
+  if(el) el.classList.toggle('visible');
+}
+
 // pen buttons helper
 function feedFishPen(i){ currentPenIndex=i; feedFish(); updateDisplay(); }
 function harvestPenIndex(i){ openHarvestModal(i); }
@@ -990,6 +995,7 @@ Object.assign(window, {
   openSellModal,
   closeSellModal,
   sellCargo,
+  toggleSection,
   saveGame,
   resetGame,
   previousSite,

--- a/style.css
+++ b/style.css
@@ -134,6 +134,25 @@ button:active {
   transition: background-color 0.3s;
 }
 
+/* Shop collapsible sections */
+.shopSection {
+  margin-top: 8px;
+  padding: 6px;
+  background-color: #2b3b4a;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: bold;
+}
+.shopSection-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+.shopSection-content.visible {
+  max-height: 500px;
+  overflow: hidden;
+}
+
 /* ===== MODAL OVERLAY ===== */
 #modal,
 #restockModal,


### PR DESCRIPTION
## Summary
- organize shop UI into collapsible sections for Barge Upgrades, Staff and Vessels
- hide and show sections with new CSS rules
- implement `toggleSection` JS helper and expose it globally
- move staff and vessel buttons into new sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae28034b48329af1fd4f2f512da5e