### PR TITLE
Improve shop section collapse

### DIFF
--- a/style.css
+++ b/style.css
@@ -144,13 +144,14 @@ button:active {
   font-weight: bold;
 }
 .shopSection-content {
+  display: none;
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.3s ease;
 }
 .shopSection-content.visible {
+  display: block;
   max-height: 500px;
-  overflow: hidden;
 }
 
 /* ===== MODAL OVERLAY ===== */


### PR DESCRIPTION
## Summary
- hide shop sections by default using `display: none`
- show sections with `display: block` when the `visible` class is toggled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aee0834688329bfd33b7da9338300