### PR TITLE
Implement tab navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,15 @@
       </div>
     </div>
 
+    <div id="tabBar" class="tabBar">
+      <button id="overviewTab" onclick="showTab('overview')" class="active">Overview</button>
+      <button id="pensTab" onclick="showTab('pens')">Pens</button>
+      <button id="bargesTab" onclick="showTab('barges')">Barges</button>
+      <button id="vesselsTab" onclick="showTab('vessels')">Vessels</button>
+      <button id="staffingTab" onclick="showTab('staffing')">Staffing</button>
+      <button id="shopTab" onclick="showTab('shop')">Shop</button>
+    </div>
+
 
     <!-- Status cards -->
     <div id="cardContainer" class="cardContainer">

--- a/script.js
+++ b/script.js
@@ -826,6 +826,57 @@ function toggleSection(id){
   if(el) el.classList.toggle('visible');
 }
 
+function closeSidebar(){
+  const sb = document.getElementById('sidebar');
+  const container = document.querySelector('.container');
+  sb.classList.remove('open');
+  container.classList.remove('shifted');
+  document.querySelectorAll('#sidebar .panel').forEach(x=>x.classList.remove('visible'));
+  document.querySelectorAll('#sidebarContent button').forEach(x=>x.classList.remove('active'));
+}
+
+function showTab(tab){
+  closeSidebar();
+  document.querySelectorAll('#tabBar button').forEach(b=>b.classList.remove('active'));
+  const btn = document.getElementById(tab+'Tab');
+  if(btn) btn.classList.add('active');
+  const hide = id => { const el=document.getElementById(id); if(el) el.style.display='none'; };
+  hide('cardContainer');
+  hide('penGrid');
+  hide('harvestInfo');
+  hide('bargeCard');
+  hide('vesselCard');
+  hide('staffCard');
+
+  switch(tab){
+    case 'overview':
+      document.getElementById('cardContainer').style.display='block';
+      document.getElementById('harvestInfo').style.display='block';
+      document.getElementById('bargeCard').style.display='block';
+      document.getElementById('vesselCard').style.display='block';
+      document.getElementById('staffCard').style.display='block';
+      break;
+    case 'pens':
+      document.getElementById('penGrid').style.display='block';
+      break;
+    case 'barges':
+      document.getElementById('cardContainer').style.display='block';
+      document.getElementById('bargeCard').style.display='block';
+      break;
+    case 'vessels':
+      document.getElementById('cardContainer').style.display='block';
+      document.getElementById('vesselCard').style.display='block';
+      break;
+    case 'staffing':
+      document.getElementById('cardContainer').style.display='block';
+      document.getElementById('staffCard').style.display='block';
+      break;
+    case 'shop':
+      togglePanel('shop');
+      break;
+  }
+}
+
 // pen buttons helper
 function feedFishPen(i){ currentPenIndex=i; feedFish(); updateDisplay(); }
 function harvestPenIndex(i){ openHarvestModal(i); }
@@ -1009,7 +1060,8 @@ Object.assign(window, {
   renameVessel,
   openMoveVesselModal,
   closeMoveModal,
-  moveVesselTo
+  moveVesselTo,
+  showTab
 });
 
 // Initialize
@@ -1017,5 +1069,6 @@ document.addEventListener("DOMContentLoaded",()=>{
   loadGame();
   updateDisplay();
   setupMapInteractions();
+  showTab('overview');
   setInterval(saveGame, AUTO_SAVE_INTERVAL_MS);
 });

--- a/style.css
+++ b/style.css
@@ -32,6 +32,26 @@ button:active {
   transform: scale(0.97);
 }
 
+/* Tab Bar */
+#tabBar {
+  margin-top: 10px;
+}
+
+#tabBar button {
+  background-color: #2b3b4a;
+  color: #dbe5ed;
+  border: none;
+  border-radius: 6px 6px 0 0;
+  padding: 6px 12px;
+  margin: 0 2px;
+  cursor: pointer;
+}
+
+#tabBar button.active {
+  background-color: #4be0ff;
+  color: #343b43;
+}
+
 /* Sidebar Layout */
 #sidebar {
   position: fixed;


### PR DESCRIPTION
## Summary
- add tab bar under the site selector
- style tab bar and active tab
- add JS helper to close sidebar and switch tabs
- expose `showTab()` and call it on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bc236b4448329ad19efe8918d7d98