### PR TITLE
Enable barge control on pens tab

### DIFF
--- a/script.js
+++ b/script.js
@@ -857,6 +857,8 @@ function showTab(tab){
       document.getElementById('staffCard').style.display='block';
       break;
     case 'pens':
+      document.getElementById('cardContainer').style.display='block';
+      document.getElementById('bargeCard').style.display='block';
       document.getElementById('penGrid').style.display='block';
       break;
     case 'barges':

--- a/style.css
+++ b/style.css
@@ -228,6 +228,10 @@ button:active {
   margin-top: 10px;
 }
 
+#penGrid {
+  margin-top: 8px;
+}
+
 .penCard {
   background: #1f2d35;
   border-radius: 10px;
@@ -298,7 +302,7 @@ button:active {
   background: #1f2d35;
   border-radius: 10px;
   padding: 16px;
-  margin: 16px auto;
+  margin: 16px auto 8px;
   color: #dbe5ed;
   box-shadow: 0 0 4px #0005;
   max-width: 300px;


### PR DESCRIPTION
## Summary
- show the barge selector while viewing pens
- tweak margins when barge card is shown with pens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bca14c14c8329a528b5c29565b140