### PR TITLE
Implement seasonal time system

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Aquaculture Empire is a small browser-based aquaculture management game written 
 - Operate harvest vessels, move them between sites and markets and sell cargo.
 - Interactive map displays sites, markets and vessel locations.
 - Game state is saved in local storage so progress persists across sessions.
+- In-game time tracks days, seasons and years that advance automatically.
 
 ## Getting Started
 No build steps are required. Open `index.html` in any modern web browser to start the game. Everything runs locally in the browser.

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
       </div>
       <div class="top-right">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
+        <div><strong>Date:</strong> <span id="dateDisplay">Spring 1, Year 1</span></div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- track game days, seasons and years
- display current date in the top bar
- automatically advance the day every 10 seconds
- save and load time state
- mention new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bedc6f0648329b62997cca5c9ed57