### PR TITLE
Expose time state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Aquaculture Empire is a small browser-based aquaculture management game written 
 - Game state is saved in local storage so progress persists across sessions.
 - In-game time tracks days, seasons and years that advance automatically.
 
+### Time Data
+Several read-only time values are exposed on the global `window` object:
+
+- `currentDayInSeason` – day number within the season (1–30)
+- `currentSeason` – season name such as "Spring"
+- `currentYear` – the current year count
+- `totalDaysElapsed` – total days since starting the game
+
+You can also call `getTimeState()` to retrieve these values as an object for
+use in mods or custom event hooks.
+
 ## Getting Started
 No build steps are required. Open `index.html` in any modern web browser to start the game. Everything runs locally in the browser.
 

--- a/script.js
+++ b/script.js
@@ -39,6 +39,23 @@ let dayInSeason = 1;
 let seasonIndex = 0;
 let year = 1;
 
+// Expose read-only accessors for external logic
+Object.defineProperties(window, {
+  currentDayInSeason: { get: () => dayInSeason },
+  currentSeason:      { get: () => SEASONS[seasonIndex] },
+  currentYear:        { get: () => year },
+  totalDaysElapsed:   { get: () => totalDaysElapsed }
+});
+
+function getTimeState(){
+  return {
+    currentDayInSeason: dayInSeason,
+    currentSeason: SEASONS[seasonIndex],
+    currentYear: year,
+    totalDaysElapsed
+  };
+}
+
 function getDateString(){
   return `${SEASONS[seasonIndex]} ${dayInSeason}, Year ${year}`;
 }
@@ -1132,7 +1149,8 @@ Object.assign(window, {
   closeMoveModal,
   moveVesselTo,
   showTab,
-  updateSelectedBargeDisplay
+  updateSelectedBargeDisplay,
+  getTimeState
 });
 
 // Initialize


### PR DESCRIPTION
## Summary
- expose current time data through read-only globals
- document available time state helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bf039cc50832993357f2c8b766b7c