### PR TITLE
Fix harvest amount precision

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
       <div id="harvestModalContent">
         <h2>Select Biomass to Harvest</h2>
         <div>Max: <span id="harvestMax">0</span> kg</div>
-        <input type="number" id="harvestAmount" min="0" step="0.1">
+        <input type="number" id="harvestAmount" min="0" step="0.01">
         <button onclick="confirmHarvest()">Harvest</button>
         <button onclick="closeHarvestModal()">Cancel</button>
       </div>

--- a/script.js
+++ b/script.js
@@ -460,7 +460,7 @@ function openHarvestModal(i){
   document.getElementById('harvestMax').innerText = maxHarvest.toFixed(2);
   const input = document.getElementById('harvestAmount');
   input.max = maxHarvest;
-  input.value = maxHarvest.toFixed(2);
+  input.value = maxHarvest.toFixed(3);
   document.getElementById('harvestModal').classList.add('visible');
 }
 function closeHarvestModal(){ document.getElementById('harvestModal').classList.remove('visible'); }
@@ -805,7 +805,8 @@ function harvestPen(amount=null){
   );
   if(maxHarvest <= 0) return openModal("Vessel capacity full.");
   let desired = amount === null ? maxHarvest : Math.max(0, Math.min(amount, maxHarvest));
-  let fishNum = Math.floor(desired / pen.averageWeight);
+  let fishNum = Math.floor((desired + pen.averageWeight * 0.0001) / pen.averageWeight);
+  if(fishNum === 0 && desired > 0) fishNum = 1;
   fishNum = Math.min(fishNum, pen.fishCount);
   const biomass = fishNum * pen.averageWeight;
   const performHarvest = ()=>{


### PR DESCRIPTION
## Summary
- allow fine grain harvest amounts in the UI
- show three decimals for default harvest value
- round up fish count when the requested biomass is near a single fish's weight

## Testing
- `apt-get update`
- `apt-get install -y nodejs npm` *(fails: unable to locate packages)*

------
https://chatgpt.com/codex/tasks/task_e_687d3b6803348329b734484266449f9a