### PR TITLE
Implement dynamic harvester rate

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,6 +18,7 @@ import { Site, Barge, Pen, Vessel } from './models.js';
 // Core Game State
 let cash = 200;
 const BASE_HARVEST_CAPACITY = 50;
+const HARVESTER_RATE = 10; // kg per second per harvester
 let penPurchaseCost = 1000;
 let currentPenIndex = 0;
 let currentSiteIndex = 0;
@@ -984,9 +985,9 @@ function getFeederRate(f){
 function getStaffFeedRate(site){
   return site.staff.filter(s=>s.role==='feeder').length;
 }
-function getSiteHarvestCapacity(site){
+function getSiteHarvestCapacity(site, elapsedSeconds = 1){
   const harvesters = site.staff.filter(s=>s.role==='harvester').length;
-  return BASE_HARVEST_CAPACITY + harvesters * 10;
+  return BASE_HARVEST_CAPACITY + (HARVESTER_RATE * harvesters * elapsedSeconds);
 }
 
 // --- AUTO-FEED ALL SITES & PENS EVERY SECOND ---


### PR DESCRIPTION
## Summary
- add `HARVESTER_RATE` constant for harvester output per second
- update `getSiteHarvestCapacity` to compute extra capacity from harvesters using time elapsed and rate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4d514e8c8329895d5a0bb875878e