### PR TITLE
Simplify interface layout

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -404,32 +404,25 @@ function addDevCash() {
 
 // sidebar nav
 function togglePanel(id){
-  const sb = document.getElementById('sidebar');
-  const container = document.querySelector('.container');
-  const p  = document.getElementById(id);
-  if(!sb.classList.contains('open')) {
-    sb.classList.add('open');
-    container.classList.add('shifted');
-  } else {
-    container.classList.add('shifted');
-  }
-  document.querySelectorAll('#sidebar .panel').forEach(x=>x.classList.remove('visible'));
-  document.querySelectorAll('#sidebarContent button').forEach(x=>x.classList.remove('active'));
-  p.classList.add('visible');
-  document.getElementById('toggle'+state.capitalizeFirstLetter(id)).classList.add('active');
+  const p = document.getElementById(id);
+  if(p) p.classList.toggle('visible');
 }
-document.getElementById('toggleSidebar').addEventListener('click',()=>{
-  const sb = document.getElementById('sidebar');
-  const container = document.querySelector('.container');
-  sb.classList.toggle('open');
-  if(sb.classList.contains('open')){
-    container.classList.add('shifted');
-  } else {
-    container.classList.remove('shifted');
-    document.querySelectorAll('#sidebar .panel').forEach(x=>x.classList.remove('visible'));
-    document.querySelectorAll('#sidebarContent button').forEach(x=>x.classList.remove('active'));
-  }
-});
+const toggleSidebarBtn = document.getElementById('toggleSidebar');
+if(toggleSidebarBtn){
+  toggleSidebarBtn.addEventListener('click', () => {
+    const sb = document.getElementById('sidebar');
+    const container = document.querySelector('.container');
+    if(!sb) return;
+    sb.classList.toggle('open');
+    if(sb.classList.contains('open')){
+      container.classList.add('shifted');
+    } else {
+      container.classList.remove('shifted');
+      document.querySelectorAll('#sidebar .panel').forEach(x=>x.classList.remove('visible'));
+      document.querySelectorAll('#sidebarContent button').forEach(x=>x.classList.remove('active'));
+    }
+  });
+}
 
 function toggleSection(id){
   const el = document.getElementById(id);
@@ -439,54 +432,14 @@ function toggleSection(id){
 function closeSidebar(){
   const sb = document.getElementById('sidebar');
   const container = document.querySelector('.container');
-  sb.classList.remove('open');
-  container.classList.remove('shifted');
+  if(sb) sb.classList.remove('open');
+  if(container) container.classList.remove('shifted');
   document.querySelectorAll('#sidebar .panel').forEach(x=>x.classList.remove('visible'));
   document.querySelectorAll('#sidebarContent button').forEach(x=>x.classList.remove('active'));
 }
 
 function showTab(tab){
-  closeSidebar();
-  document.querySelectorAll('#tabBar button').forEach(b=>b.classList.remove('active'));
-  const btn = document.getElementById(tab+'Tab');
-  if(btn) btn.classList.add('active');
-  const hide = id => { const el=document.getElementById(id); if(el) el.style.display='none'; };
-  hide('cardContainer');
-  hide('penGrid');
-  hide('harvestInfo');
-  hide('bargeCard');
-  hide('vesselCard');
-  hide('staffCard');
-
-  switch(tab){
-    case 'overview':
-      document.getElementById('cardContainer').style.display='block';
-      document.getElementById('harvestInfo').style.display='block';
-      document.getElementById('bargeCard').style.display='block';
-      document.getElementById('vesselCard').style.display='block';
-      document.getElementById('staffCard').style.display='block';
-      break;
-    case 'pens':
-      document.getElementById('cardContainer').style.display='block';
-      document.getElementById('bargeCard').style.display='block';
-      document.getElementById('penGrid').style.display='block';
-      break;
-    case 'barges':
-      document.getElementById('cardContainer').style.display='block';
-      document.getElementById('bargeCard').style.display='block';
-      break;
-    case 'vessels':
-      document.getElementById('cardContainer').style.display='block';
-      document.getElementById('vesselCard').style.display='block';
-      break;
-    case 'staffing':
-      document.getElementById('cardContainer').style.display='block';
-      document.getElementById('staffCard').style.display='block';
-      break;
-    case 'shop':
-      togglePanel('shop');
-      break;
-  }
+  // Tab navigation removed in new layout
 }
 
 // pen buttons helper

--- a/index.html
+++ b/index.html
@@ -6,73 +6,6 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <button id="toggleSidebar">☰</button>
-  <div id="sidebar">
-    <div id="sidebarContent">
-      <button id="toggleShop" onclick="togglePanel('shop')">&#128722;</button>
-      <button id="toggleDevMenu" onclick="togglePanel('devMenu')">🛠</button>
-      <button id="toggleMap" onclick="togglePanel('map')">🗺️</button>
-      <div id="shop" class="panel">
-        <h2>Shop</h2>
-        <div id="feedPurchaseButtons">
-          <button onclick="buyFeed(20)">+20kg Feed</button>
-          <button onclick="buyFeed(100)">+100kg Feed</button>
-          <button onclick="buyMaxFeed()">Buy Max</button>
-        </div>
-
-        <div class="shopSection" onclick="toggleSection('bargeOptions')">Barge Upgrades</div>
-        <div id="bargeOptions" class="shopSection-content">
-          <button onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
-          <button onclick="buyNewBarge()">Buy Barge</button>
-          <button onclick="upgradeBarge()">Upgrade Barge</button>
-          <button onclick="buyNewPen()">+ Pen</button>
-        </div>
-
-        <div class="shopSection" onclick="toggleSection('staffOptions')">Staff</div>
-        <div id="staffOptions" class="shopSection-content">
-          <button onclick="hireStaff()">Hire Staff ($500)</button>
-          <button onclick="fireStaff()">Fire Unassigned</button>
-          <button onclick="assignStaff('feeder')">Assign Feeder</button>
-          <button onclick="unassignStaff('feeder')">Remove Feeder</button>
-          <button onclick="assignStaff('harvester')">Assign Harvester</button>
-          <button onclick="unassignStaff('harvester')">Remove Harvester</button>
-          <button onclick="assignStaff('feedManager')">Assign Feed Manager</button>
-          <button onclick="unassignStaff('feedManager')">Remove Feed Manager</button>
-          <button onclick="upgradeStaffHousing()">Upgrade Housing</button>
-        </div>
-
-        <div class="shopSection" onclick="toggleSection('vesselOptions')">Vessels</div>
-        <div id="vesselOptions" class="shopSection-content">
-          <button onclick="renameVessel()">Rename Vessel</button>
-          <button onclick="upgradeVessel()">Upgrade Vessel</button>
-          <button onclick="buyNewVessel()">Buy Vessel</button>
-          <button onclick="openMoveVesselModal()">Move Vessel</button>
-          <button onclick="openSellModal()">Sell Cargo</button>
-        </div>
-
-        <div id="storageUpgradeInfo"></div>
-        <div id="housingUpgradeInfo"></div>
-        <div id="bargeUpgradeInfo"></div>
-        <div id="bargePurchaseInfo"></div>
-        <div id="penPurchaseInfo"></div>
-        <div id="licenseShop"></div>
-        <div id="statusMessages"></div>
-      </div>
-      <div id="devMenu" class="panel">
-        <h2>Dev</h2>
-        <button onclick="addDevCash()">+ $1M</button>
-        <button onclick="saveGame()">Save Game</button>
-        <button onclick="resetGame()">Reset Game</button>
-      </div>
-      <div id="map" class="panel">
-        <h2>Map</h2>
-        <div id="mapContainer">
-          <canvas id="mapCanvas" width="400" height="300"></canvas>
-          <div id="mapTooltip"></div>
-        </div>
-      </div>
-    </div>
-  </div>
 
   <div class="container">
     <!-- Top bar: site nav on left, cash on right -->
@@ -90,18 +23,10 @@
       </div>
     </div>
 
-    <div id="tabBar" class="tabBar">
-      <button id="overviewTab" onclick="showTab('overview')" class="active">Overview</button>
-      <button id="pensTab" onclick="showTab('pens')">Pens</button>
-      <button id="bargesTab" onclick="showTab('barges')">Barges</button>
-      <button id="vesselsTab" onclick="showTab('vessels')">Vessels</button>
-      <button id="staffingTab" onclick="showTab('staffing')">Staffing</button>
-      <button id="shopTab" onclick="showTab('shop')">Shop</button>
-    </div>
-
-
-    <!-- Status cards -->
-    <div id="cardContainer" class="cardContainer">
+    <div id="mainLayout">
+      <div id="rightPanel">
+        <!-- Status cards -->
+        <div id="cardContainer" class="cardContainer">
       <div id="bargeCard" class="bargeCard">
         <h2>Barge Status</h2>
         <div>
@@ -143,8 +68,56 @@
       </div>
     </div>
 
-    <!-- Harvest info (single-pen harvest preview) -->
-    <div id="harvestInfo" class="harvestInfo"></div>
+    <div id="shop" class="shopPanel">
+      <h2>Shop</h2>
+      <div id="feedPurchaseButtons">
+        <button onclick="buyFeed(20)">+20kg Feed</button>
+        <button onclick="buyFeed(100)">+100kg Feed</button>
+        <button onclick="buyMaxFeed()">Buy Max</button>
+      </div>
+
+      <div class="shopSection" onclick="toggleSection('bargeOptions')">Barge Upgrades</div>
+      <div id="bargeOptions" class="shopSection-content">
+        <button onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
+        <button onclick="buyNewBarge()">Buy Barge</button>
+        <button onclick="upgradeBarge()">Upgrade Barge</button>
+        <button onclick="buyNewPen()">+ Pen</button>
+      </div>
+
+      <div class="shopSection" onclick="toggleSection('staffOptions')">Staff</div>
+      <div id="staffOptions" class="shopSection-content">
+        <button onclick="hireStaff()">Hire Staff ($500)</button>
+        <button onclick="fireStaff()">Fire Unassigned</button>
+        <button onclick="assignStaff('feeder')">Assign Feeder</button>
+        <button onclick="unassignStaff('feeder')">Remove Feeder</button>
+        <button onclick="assignStaff('harvester')">Assign Harvester</button>
+        <button onclick="unassignStaff('harvester')">Remove Harvester</button>
+        <button onclick="assignStaff('feedManager')">Assign Feed Manager</button>
+        <button onclick="unassignStaff('feedManager')">Remove Feed Manager</button>
+        <button onclick="upgradeStaffHousing()">Upgrade Housing</button>
+      </div>
+
+      <div class="shopSection" onclick="toggleSection('vesselOptions')">Vessels</div>
+      <div id="vesselOptions" class="shopSection-content">
+        <button onclick="renameVessel()">Rename Vessel</button>
+        <button onclick="upgradeVessel()">Upgrade Vessel</button>
+        <button onclick="buyNewVessel()">Buy Vessel</button>
+        <button onclick="openMoveVesselModal()">Move Vessel</button>
+        <button onclick="openSellModal()">Sell Cargo</button>
+      </div>
+
+      <div id="storageUpgradeInfo"></div>
+      <div id="housingUpgradeInfo"></div>
+      <div id="bargeUpgradeInfo"></div>
+      <div id="bargePurchaseInfo"></div>
+      <div id="penPurchaseInfo"></div>
+      <div id="licenseShop"></div>
+      <div id="statusMessages"></div>
+    </div>
+      </div>
+      <div id="leftPanel">
+        <!-- Harvest info (single-pen harvest preview) -->
+        <div id="harvestInfo" class="harvestInfo"></div>
 
     <!-- Pen grid -->
     <div id="penGrid">
@@ -156,6 +129,8 @@
         <span id="selectedBargeDisplay"></span>
       </div>
       <div id="penGridContainer" class="grid"></div>
+    </div>
+      </div>
     </div>
 
     <!-- Modals -->

--- a/script.js
+++ b/script.js
@@ -8,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
   actions.loadGame();
   ui.updateDisplay();
   ui.setupMapInteractions();
-  actions.showTab('overview');
   if(state.lastOfflineInfo){
     const days = state.lastOfflineInfo.daysPassed;
     const feed = state.lastOfflineInfo.feedUsed.toFixed(0);

--- a/style.css
+++ b/style.css
@@ -404,3 +404,32 @@ button:active {
     transform: translateX(0);
   }
 }
+
+/* New incremental layout */
+#mainLayout {
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+}
+
+#leftPanel {
+  flex: 2;
+}
+
+#rightPanel {
+  flex: 1;
+  min-width: 260px;
+}
+
+#shop.shopPanel {
+  background: #1f2d35;
+  border-radius: 10px;
+  padding: 16px;
+  margin-top: 16px;
+  box-shadow: 0 0 4px #0005;
+}
+
+#shop button {
+  width: 100%;
+  margin: 4px 0;
+}


### PR DESCRIPTION
## Summary
- remove sidebar-based layout and create new two-panel UI
- simplify showTab and sidebar helpers
- adjust script startup for new layout
- add main layout styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ea14f9de083299041222f1819db0e