### PR TITLE
Add dev menu actions for harvesting and restocking all pens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Aquaculture Empire is a small browser-based aquaculture management game written 
 - Each pen has a tiered auto-feeder path from floating rafts to
   underwater systems with individual upgrade costs.
 - Expand your business by buying entirely new sites.
-- Development menu with a helper button to add cash instantly.
+- Development menu with helper buttons to add cash, harvest all pens and restock them for free.
 - Progress is automatically saved every 30 seconds.
 - Hire and assign staff as feeders, harvesters or feed managers.
 - Upgrade staff housing and barge tiers to unlock more automation.

--- a/actions.js
+++ b/actions.js
@@ -404,6 +404,28 @@ function addDevCash() {
   updateDisplay();
 }
 
+function devHarvestAll(){
+  state.sites.forEach(site=>{
+    site.pens.forEach(pen=>{
+      pen.fishCount = 0;
+      pen.averageWeight = 0;
+    });
+  });
+  updateDisplay();
+}
+
+function devRestockAll(){
+  state.sites.forEach(site=>{
+    site.pens.forEach(pen=>{
+      const data = speciesData[pen.species];
+      if(!data) return;
+      pen.fishCount = data.restockCount;
+      pen.averageWeight = data.startingWeight;
+    });
+  });
+  updateDisplay();
+}
+
 // sidebar nav
 function togglePanel(id){
   const p = document.getElementById(id);
@@ -687,4 +709,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState  };
+export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState  };

--- a/index.html
+++ b/index.html
@@ -109,6 +109,8 @@
       <div class="shopSection" onclick="toggleSection('devMenu')">Dev Menu</div>
       <div id="devMenu" class="shopSection-content">
         <button onclick="addDevCash()">Add $100k</button>
+        <button onclick="devHarvestAll()">Harvest All Pens</button>
+        <button onclick="devRestockAll()">Restock All (Free)</button>
       </div>
 
       <div id="storageUpgradeInfo"></div>


### PR DESCRIPTION
## Summary
- add `devHarvestAll` and `devRestockAll` utilities
- export them from `actions.js`
- show new buttons in Dev Menu section of `index.html`
- document dev menu options in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ed76b79fc83299ce0e410b4dae9ee