### PR TITLE
Add site dropdown and header nav

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -735,6 +735,14 @@ function resetGame() {
 function previousSite(){ if(state.currentSiteIndex>0) state.currentSiteIndex--; state.currentPenIndex=0; state.currentBargeIndex=0; updateDisplay(); }
 function nextSite(){ if(state.currentSiteIndex<state.sites.length-1) state.currentSiteIndex++; state.currentPenIndex=0; state.currentBargeIndex=0; updateDisplay(); }
 
+function setCurrentSite(idx){
+  if(idx < 0 || idx >= state.sites.length) return;
+  state.currentSiteIndex = idx;
+  state.currentPenIndex = 0;
+  state.currentBargeIndex = 0;
+  updateDisplay();
+}
+
 function previousBarge(){ if(state.currentBargeIndex>0) state.currentBargeIndex--; updateDisplay(); }
 function nextBarge(){ const site = state.sites[state.currentSiteIndex]; if(state.currentBargeIndex<site.barges.length-1) state.currentBargeIndex++; updateDisplay(); }
 function previousVessel(){ if(state.currentVesselIndex>0) state.currentVesselIndex--; updateDisplay(); }
@@ -742,4 +750,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState  };
+export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState, setCurrentSite };

--- a/index.html
+++ b/index.html
@@ -8,20 +8,24 @@
 <body>
 
   <div class="container">
-    <!-- Top bar: site nav on left, cash on right -->
-    <div id="topBar">
+    <!-- Header with navigation and site selector -->
+    <header id="topBar">
+      <nav class="main-nav">
+        <a href="#">Dashboard</a>
+        <a href="#">Shop</a>
+        <a href="#">Reports</a>
+        <a href="#">Sites</a>
+      </nav>
       <div class="top-left">
         <strong>Site:</strong>
-        <span id="siteName">-</span>
-        <button onclick="previousSite()">⟵</button>
-        <button onclick="nextSite()">⟶</button>
+        <select id="siteSelect"></select>
         <button onclick="buyNewSite()">+ New Site</button>
       </div>
       <div class="top-right">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
         <div><strong>Date:</strong> <span id="dateDisplay">Spring 1, Year 1</span></div>
       </div>
-    </div>
+    </header>
 
     <div id="mainLayout">
       <div id="rightPanel">

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ body {
   background: #1a272e;
   color: #dbe5ed;
   text-align: center;
-  margin-top: 30px;
+  margin-top: 80px;
   overflow-x: hidden; /* prevent horizontal scroll on mobile */
 }
 .container {
@@ -363,16 +363,33 @@ button:active {
   margin: 6px 0;
 }
 #topBar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: #1f2d35;
+  background-color: #142027;
   padding: 12px 16px;
-  margin: 10px auto 20px;
-  border-radius: 8px;
-  box-shadow: 0 0 6px #0006;
+  box-shadow: 0 2px 6px #0006;
   color: #dbe5ed;
-  max-width: 900px;
+  z-index: 100;
+}
+
+.main-nav {
+  display: flex;
+  gap: 20px;
+}
+
+.main-nav a {
+  color: #dbe5ed;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.main-nav a:hover {
+  color: #4be0ff;
 }
 
 .top-left, .top-right {

--- a/ui.js
+++ b/ui.js
@@ -18,9 +18,30 @@ import state, {
 } from "./gameState.js";
 
 // --- UPDATE UI ---
+function updateSiteSelect(){
+  const select = document.getElementById('siteSelect');
+  if(!select) return;
+  select.innerHTML = '';
+  state.sites.forEach((s,i)=>{
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = s.name;
+    select.appendChild(opt);
+  });
+  select.value = state.currentSiteIndex;
+  if(!select.dataset.bound){
+    select.addEventListener('change', e=>{
+      if(window.setCurrentSite) window.setCurrentSite(Number(e.target.value));
+    });
+    select.dataset.bound = 'true';
+  }
+}
+
 function updateDisplay(){
   const site = state.sites[state.currentSiteIndex];
   const pen  = site.pens[state.currentPenIndex];
+
+  updateSiteSelect();
 
   // top-bar
   document.getElementById('siteName').innerText = site.name;
@@ -426,6 +447,7 @@ function sellCargo(idx){
 
 // --- PURCHASES & ACTIONS ---
 export {
+  updateSiteSelect,
   updateDisplay,
   updateHarvestInfo,
   updateLicenseShop,


### PR DESCRIPTION
## Summary
- replace site navigation arrows with dropdown selector
- add header navigation links
- keep header fixed with dark styling
- update UI and actions scripts for new site selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f0e04bafc8329a56432a62a8ecccd