### PR TITLE
Improve right panel cards

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -102,7 +102,7 @@ state.advanceDays = advanceDays;
 
 function addStatusMessage(msg) {
   state.statusMessage = msg;
-  const el = document.getElementById('statusMessages');
+  const el = document.getElementById('notifications');
   if(el) el.innerText = msg;
 }
 

--- a/index.html
+++ b/index.html
@@ -27,20 +27,26 @@
       <div id="rightPanel">
         <!-- Status cards -->
         <div id="cardContainer" class="cardContainer">
-      <div id="bargeCard" class="bargeCard">
-        <h2>Barge Status</h2>
-        <div>
-          <button onclick="previousBarge()">⟵</button>
-          Barge <span id="bargeIndex">1</span>/<span id="bargeCount">1</span>
-          <button onclick="nextBarge()">⟶</button>
-        </div>
-        <div>Barge Tier: <span id="bargeTierName">Small</span></div>
-        <div>Feeders: <span id="bargeFeedersUsed">0</span>/<span id="bargeFeederLimit">0</span> (Max Tier <span id="bargeMaxFeederTier">0</span>)</div>
-        <div>Feed: <span id="bargeFeed">0</span> / <span id="bargeFeedCapacity">0</span> kg</div>
-        <div>Silo Capacity: <span id="bargeSiloCapacity">0</span> kg</div>
-        <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
-        <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
-      </div>
+          <div id="feedStorageCard" class="infoCard">
+            <h2>Feed Storage</h2>
+            <div class="progress-label">Feed: <span id="bargeFeed">0</span> / <span id="bargeFeedCapacity">0</span> kg</div>
+            <div class="progress"><div id="feedProgress" class="progress-bar"></div></div>
+            <div class="progress-label">Silo Capacity: <span id="bargeSiloCapacity">0</span> kg</div>
+            <div class="progress"><div id="siloProgress" class="progress-bar"></div></div>
+          </div>
+
+          <div id="bargeMgmtCard" class="infoCard">
+            <h2>Barge Management</h2>
+            <div>
+              <button onclick="previousBarge()">⟵</button>
+              Barge <span id="bargeIndex">1</span>/<span id="bargeCount">1</span>
+              <button onclick="nextBarge()">⟶</button>
+            </div>
+            <div>Barge Tier: <span id="bargeTierName">Small</span></div>
+            <div>Feeders: <span id="bargeFeedersUsed">0</span>/<span id="bargeFeederLimit">0</span> (Max Tier <span id="bargeMaxFeederTier">0</span>)</div>
+            <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
+            <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
+          </div>
       <div id="vesselCard" class="vesselCard">
         <h2>Vessel Status</h2>
         <div>
@@ -69,6 +75,17 @@
         <div>Feed Managers: <span id="staffManagers">0</span></div>
         <div id="staffActionPlaceholder"></div>
       </div>
+
+      <div id="tipsCard" class="infoCard">
+        <h2>Operational Tips</h2>
+        <ul id="tipsList">
+          <li>Keep feed above 20% capacity.</li>
+          <li>Upgrade storage to expand operations.</li>
+          <li>Hire managers for automation.</li>
+        </ul>
+      </div>
+
+      <div id="notifications" class="notifications"></div>
     </div>
 
     <div id="shop" class="shopPanel">
@@ -123,7 +140,6 @@
       <div id="bargePurchaseInfo"></div>
       <div id="penPurchaseInfo"></div>
       <div id="licenseShop"></div>
-      <div id="statusMessages"></div>
     </div>
       </div>
       <div id="leftPanel">

--- a/style.css
+++ b/style.css
@@ -306,61 +306,66 @@ button:active {
 #feedPurchaseButtons button {
   display: inline-block;
 }
-#statusMessages {
-  margin-top: 10px;
-  font-size: 14px;
-  color: #4be0ff;
-}
-.bargeCard {
-  background: #1f2d35;
-  border-radius: 10px;
-  padding: 16px;
-  margin: 16px auto 8px;
-  color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
-  max-width: 300px;
-}
-.vesselCard {
-  background: #1f2d35;
-  border-radius: 10px;
-  padding: 16px;
-  margin: 16px auto;
-  color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
-  max-width: 300px;
-}
+
+
+.infoCard,
+.bargeCard,
+.vesselCard,
 .staffCard {
   background: #1f2d35;
   border-radius: 10px;
   padding: 16px;
   margin: 16px auto;
   color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
+  box-shadow: 0 0 6px #0005;
   max-width: 300px;
 }
+
 .cardContainer {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   gap: 16px;
 }
-.bargeCard h2 {
+
+.infoCard h2,
+.bargeCard h2,
+.vesselCard h2,
+.staffCard h2 {
   font-size: 18px;
   margin-bottom: 10px;
   color: #4be0ff;
 }
-.bargeCard div {
+
+.infoCard div,
+.infoCard li,
+.bargeCard div,
+.vesselCard div,
+.staffCard div {
   font-size: 14px;
   margin: 6px 0;
 }
-.vesselCard h2 {
-  font-size: 18px;
-  margin-bottom: 10px;
+
+.progress {
+  background: #2b3b4a;
+  border-radius: 6px;
+  height: 12px;
+  width: 100%;
+  overflow: hidden;
+  margin-top: 4px;
+}
+
+.progress-bar {
+  background: #4be0ff;
+  height: 100%;
+  width: 0%;
+  transition: width 0.3s;
+}
+
+.notifications {
+  margin-top: 10px;
+  font-size: 14px;
   color: #4be0ff;
-}
-.vesselCard div {
-  font-size: 14px;
-  margin: 6px 0;
 }
 #topBar {
   display: flex;

--- a/ui.js
+++ b/ui.js
@@ -40,6 +40,12 @@ function updateDisplay(){
   document.getElementById('bargeFeed').innerText         = barge.feed.toFixed(1);
   document.getElementById('bargeFeedCapacity').innerText = barge.feedCapacity;
   document.getElementById('bargeSiloCapacity').innerText = barge.siloCapacity;
+  const feedPct = Math.min(1, barge.feed / barge.feedCapacity) * 100;
+  const feedBar = document.getElementById('feedProgress');
+  if(feedBar) feedBar.style.width = feedPct + '%';
+  const siloPct = Math.min(1, barge.feed / barge.siloCapacity) * 100;
+  const siloBar = document.getElementById('siloProgress');
+  if(siloBar) siloBar.style.width = siloPct + '%';
   document.getElementById('bargeStaffCount').innerText    = site.staff.length;
   const totalCapacity = site.barges.reduce((t,b)=>t+b.staffCapacity,0);
   document.getElementById('bargeStaffCapacity').innerText = totalCapacity;
@@ -101,7 +107,7 @@ function updateDisplay(){
   updateLicenseShop();
   renderPenGrid(site);
   renderMap();
-  const statusEl = document.getElementById('statusMessages');
+  const statusEl = document.getElementById('notifications');
   if(statusEl) statusEl.innerText = state.statusMessage;
 }
 


### PR DESCRIPTION
## Summary
- add new feed storage, barge management and tips cards
- show progress bars for feed and silo levels
- move status messages to a notifications section
- stack cards vertically with modern styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f0e05c40c8329aac8dbde2e616e4a