### PR TITLE
Enhance pen cards with progress bars and updated styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -226,7 +226,7 @@ button:active {
 
 #penGrid .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;
   margin-top: 10px;
 }
@@ -237,11 +237,11 @@ button:active {
 
 .penCard {
   background: #1f2d35;
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 12px;
   text-align: left;
   color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
+  box-shadow: 0 2px 6px #0006;
 }
 .penCard h3 {
   font-size: 18px;
@@ -269,6 +269,23 @@ button:active {
 .vesselCard button:hover {
   background-color: #4be0ff;
   color: #142027;
+}
+
+.progressBar {
+  width: 100%;
+  height: 8px;
+  background-color: #2b3b4a;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 4px 0;
+}
+.progressBar.feeder .progressFill {
+  background-color: #5cb85c;
+}
+.progressFill {
+  height: 100%;
+  background-color: #4be0ff;
+  width: 0;
 }
 
 .newPenControls {
@@ -313,29 +330,29 @@ button:active {
 }
 .bargeCard {
   background: #1f2d35;
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 16px;
   margin: 16px auto 8px;
   color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
+  box-shadow: 0 2px 6px #0006;
   max-width: 300px;
 }
 .vesselCard {
   background: #1f2d35;
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 16px;
   margin: 16px auto;
   color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
+  box-shadow: 0 2px 6px #0006;
   max-width: 300px;
 }
 .staffCard {
   background: #1f2d35;
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 16px;
   margin: 16px auto;
   color: #dbe5ed;
-  box-shadow: 0 0 4px #0005;
+  box-shadow: 0 2px 6px #0006;
   max-width: 300px;
 }
 .cardContainer {

--- a/ui.js
+++ b/ui.js
@@ -158,6 +158,10 @@ function renderPenGrid(site){
     const feederTier = pen.feeder?.tier||0;
     const nextUpgrade = feederUpgrades[feederTier];
     const nextCostText = nextUpgrade ? `Upgrade Cost: $${nextUpgrade.cost}` : 'Feeder Maxed';
+    const harvestTarget = 1; // arbitrary harvest weight per fish
+    const biomassPercent = Math.min(1, pen.averageWeight/harvestTarget)*100;
+    const barge = site.barges[pen.bargeIndex];
+    const feederPercent = barge ? (feederTier/barge.maxFeederTier)*100 : 0;
     const card = document.createElement('div');
     card.className = 'penCard';
     card.innerHTML = `
@@ -165,14 +169,16 @@ function renderPenGrid(site){
       <div class="stat">Species: ${capitalizeFirstLetter(pen.species)}</div>
       <div class="stat">Fish: ${pen.fishCount}</div>
       <div class="stat">Avg Weight: ${pen.averageWeight.toFixed(2)} kg</div>
+      <div class="progressBar"><div class="progressFill" style="width:${biomassPercent}%"></div></div>
       <div class="stat">Biomass: ${biomass.toFixed(2)} kg</div>
       <div class="stat">Feeder: ${capitalizeFirstLetter(feederType)} (Tier ${feederTier})</div>
+      <div class="progressBar feeder"><div class="progressFill" style="width:${feederPercent}%"></div></div>
       <div class="stat">Barge: <select onchange="assignBarge(${idx}, this.value)">${bargeOptions}</select></div>
       <div class="stat">${nextCostText}</div>
-      <button onclick="feedFishPen(${idx})">Feed</button>
-      <button onclick="harvestPenIndex(${idx})" ${state.vessels[state.currentVesselIndex].isHarvesting?'disabled':''}>Harvest</button>
-      <button onclick="restockPenUI(${idx})">Restock</button>
-      <button onclick="upgradeFeeder(${idx})">Upgrade Feeder</button>
+      <button onclick="feedFishPen(${idx})">🍤 Feed</button>
+      <button onclick="harvestPenIndex(${idx})" ${state.vessels[state.currentVesselIndex].isHarvesting?'disabled':''}>🐟 Harvest</button>
+      <button onclick="restockPenUI(${idx})">🔄 Restock</button>
+      <button onclick="upgradeFeeder(${idx})">⬆️ Upgrade</button>
     `;
     grid.appendChild(card);
   });


### PR DESCRIPTION
## Summary
- show progress bars for biomass and feeder tiers in `renderPenGrid`
- add icons for feed/restock/upgrade actions
- round card corners and add subtle shadows
- use auto-fit responsive columns and progress bar styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f0e07cf9c832998f2dc3112ebce9f