### PR TITLE
Add cargo species tracking and single-pen harvest

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -140,6 +140,7 @@ state.vessels = [
     name: 'Hauler 1',
     maxBiomassCapacity: vesselTiers[0].maxBiomassCapacity,
     currentBiomassLoad: 0,
+    cargoSpecies: null,
     speed: vesselTiers[0].speed,
     location: 'Dock',
     tier: 0,

--- a/index.html
+++ b/index.html
@@ -159,10 +159,10 @@
           <div class="stat">Status: <span class="vessel-status"></span></div>
           <div class="progressBar"><div class="progress vessel-progress"></div></div>
           <div class="stat"><span class="vessel-load"></span> / <span class="vessel-capacity"></span> kg</div>
-          <button class="harvest-btn">Harvest</button>
           <button class="move-btn">Move Vessel</button>
           <button class="sell-btn">Sell Cargo</button>
           <button class="upgrade-btn">Vessel Upgrades</button>
+          <button class="cancel-btn">Cancel</button>
         </div>
       </template>
     </div>
@@ -189,15 +189,6 @@
         <input type="number" id="harvestAmount" min="0" step="0.01">
         <button onclick="confirmHarvest()">Harvest</button>
         <button onclick="closeHarvestModal()">Cancel</button>
-      </div>
-    </div>
-    <div id="vesselHarvestModal">
-      <div id="vesselHarvestModalContent">
-        <h2>Select Biomass to Harvest</h2>
-        <div>Max: <span id="vesselHarvestMax">0</span> kg</div>
-        <input type="number" id="vesselHarvestAmount" min="0" step="0.01">
-        <button onclick="confirmVesselHarvest()">Harvest</button>
-        <button onclick="closeVesselHarvestModal()">Cancel</button>
       </div>
     </div>
     <div id="sellModal">

--- a/models.js
+++ b/models.js
@@ -64,6 +64,7 @@ export class Vessel {
     maxBiomassCapacity = 1000,
     currentBiomassLoad = 0,
     cargo = {},
+    cargoSpecies = null,
     speed = 10,
     location = '',
     tier = 0,
@@ -74,10 +75,17 @@ export class Vessel {
     this.maxBiomassCapacity = maxBiomassCapacity;
     this.currentBiomassLoad = currentBiomassLoad;
     this.cargo = cargo;
+    this.cargoSpecies = cargoSpecies;
     this.speed = speed;
     this.location = location;
     this.tier = tier;
     this.isHarvesting = isHarvesting;
     this.actionEndsAt = actionEndsAt;
+
+    // timers and progress (non-enumerable so they aren't saved)
+    Object.defineProperty(this, 'harvestInterval', { value: null, writable: true, enumerable: false });
+    Object.defineProperty(this, 'harvestTimeout', { value: null, writable: true, enumerable: false });
+    Object.defineProperty(this, 'harvestProgress', { value: 0, writable: true, enumerable: false });
+    Object.defineProperty(this, 'harvestFishBuffer', { value: 0, writable: true, enumerable: false });
   }
 }

--- a/style.css
+++ b/style.css
@@ -303,6 +303,13 @@ button:active {
   color: var(--bg-darker);
 }
 
+.cancel-btn {
+  background-color: #b04444;
+}
+.cancel-btn:hover {
+  background-color: #d45c5c;
+}
+
 .penCard:hover,
 .vesselCard:hover,
 .bargeCard:hover,

--- a/ui.js
+++ b/ui.js
@@ -125,7 +125,7 @@ function updateHarvestInfo(){
   const infoDiv = document.getElementById('harvestInfo');
   if(pen.fishCount>0){
     const vessel = state.vessels[state.currentVesselIndex];
-    if(vessel.currentBiomassLoad>0 && !vessel.cargo[pen.species]){
+    if(vessel.currentBiomassLoad>0 && vessel.cargoSpecies && vessel.cargoSpecies !== pen.species){
       infoDiv.innerText = 'Vessel carrying other species.';
       return;
     }
@@ -223,10 +223,10 @@ function renderVesselGrid(){
     card.querySelector('.vessel-progress').style.width = loadPercent + '%';
     card.querySelector('.vessel-load').textContent = vessel.currentBiomassLoad.toFixed(1);
     card.querySelector('.vessel-capacity').textContent = vessel.maxBiomassCapacity;
-    card.querySelector('.harvest-btn').onclick = ()=>{ state.currentVesselIndex = idx; openVesselHarvestModal(); };
     card.querySelector('.move-btn').onclick = ()=>{ state.currentVesselIndex = idx; openMoveVesselModal(); };
     card.querySelector('.sell-btn').onclick = ()=>{ state.currentVesselIndex = idx; openSellModal(); };
     card.querySelector('.upgrade-btn').onclick = ()=>{ state.currentVesselIndex = idx; upgradeVessel(); };
+    card.querySelector('.cancel-btn').onclick = ()=>{ state.currentVesselIndex = idx; cancelVesselHarvest(idx); };
     grid.appendChild(clone);
   });
 }
@@ -251,6 +251,7 @@ function updateVesselCards(){
     card.querySelector('.vessel-progress').style.width = loadPercent + '%';
     card.querySelector('.vessel-load').textContent = vessel.currentBiomassLoad.toFixed(1);
     card.querySelector('.vessel-capacity').textContent = vessel.maxBiomassCapacity;
+    card.querySelector('.cancel-btn').onclick = ()=>{ state.currentVesselIndex = idx; cancelVesselHarvest(idx); };
   });
 }
 
@@ -385,7 +386,7 @@ function openHarvestModal(i){
   const pen  = site.pens[state.currentPenIndex];
   const vessel = state.vessels[state.currentVesselIndex];
   if(vessel.isHarvesting) return openModal('Vessel currently harvesting.');
-  if(vessel.currentBiomassLoad>0 && !vessel.cargo[pen.species]){
+  if(vessel.currentBiomassLoad>0 && vessel.cargoSpecies && vessel.cargoSpecies !== pen.species){
     return openModal('Vessel already contains a different species.');
   }
   const remaining = vessel.maxBiomassCapacity - vessel.currentBiomassLoad;
@@ -411,40 +412,6 @@ function confirmHarvest(){
   updateDisplay();
 }
 
-function openVesselHarvestModal(){
-  const site = state.sites[state.currentSiteIndex];
-  const vessel = state.vessels[state.currentVesselIndex];
-  if(vessel.isHarvesting) return openModal('Vessel currently harvesting.');
-  let species = vessel.currentBiomassLoad>0 ? Object.keys(vessel.cargo)[0] : null;
-  let available = 0;
-  site.pens.forEach(pen=>{
-    if(pen.fishCount===0) return;
-    if(species && pen.species!==species) return;
-    if(!species) species = pen.species;
-    if(pen.species===species) available += pen.fishCount * pen.averageWeight;
-  });
-  const remaining = vessel.maxBiomassCapacity - vessel.currentBiomassLoad;
-  const maxHarvest = Math.min(remaining, available);
-  const rate = getSiteHarvestRate(site);
-  const secs = maxHarvest / rate;
-  if(maxHarvest<=0) return openModal('No biomass available.');
-  document.getElementById('vesselHarvestMax').innerText = maxHarvest.toFixed(2);
-  const input = document.getElementById('vesselHarvestAmount');
-  input.max = maxHarvest;
-  input.value = maxHarvest.toFixed(3);
-  document.getElementById('vesselHarvestModalContent').querySelector('h2').innerText =
-    `Select Biomass to Harvest (~${secs.toFixed(1)}s)`;
-  document.getElementById('vesselHarvestModal').classList.add('visible');
-}
-function closeVesselHarvestModal(){
-  document.getElementById('vesselHarvestModal').classList.remove('visible');
-}
-function confirmVesselHarvest(){
-  const amount = parseFloat(document.getElementById('vesselHarvestAmount').value);
-  harvestWithVessel(state.currentVesselIndex, amount);
-  closeVesselHarvestModal();
-  updateDisplay();
-}
 
 function openSellModal(){
   const optionsDiv = document.getElementById('sellOptions');
@@ -482,6 +449,7 @@ function sellCargo(idx){
     state.cash += total;
     vessel.currentBiomassLoad = 0;
     vessel.cargo = {};
+    vessel.cargoSpecies = null;
     vessel.location = market.name;
     openModal(`Sold cargo for $${total.toFixed(2)} at ${market.name}.`);
     updateDisplay();
@@ -521,9 +489,6 @@ export {
   openHarvestModal,
   closeHarvestModal,
   confirmHarvest,
-  openVesselHarvestModal,
-  closeVesselHarvestModal,
-  confirmVesselHarvest,
   openSellModal,
   closeSellModal,
   sellCargo


### PR DESCRIPTION
## Summary
- restrict harvesting to a single pen by removing multi-pen vessel harvest logic
- add `cargoSpecies` property on vessels to prevent mixing species
- track species when loading, buying, harvesting, and selling cargo
- remove unused vessel harvest modal and button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688083d9f0ec8329a595facaf63fbdfa