### PR TITLE
Implement modal-based vessel harvesting

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,8 +169,10 @@
           <div class="stat">Tier: <span class="vessel-tier"></span></div>
           <div class="stat">Location: <span class="vessel-location"></span></div>
           <div class="stat">Status: <span class="vessel-status"></span></div>
+          <div class="stat harvest-species"></div>
           <div class="progressBar"><div class="progress vessel-progress"></div></div>
           <div class="stat"><span class="vessel-load"></span> / <span class="vessel-capacity"></span> kg</div>
+          <button class="harvest-btn">Harvest</button>
           <button class="move-btn">Move Vessel</button>
           <button class="sell-btn">Sell Cargo</button>
           <button class="upgrade-btn">Vessel Upgrades</button>
@@ -196,10 +198,14 @@
     </div>
     <div id="harvestModal">
       <div id="harvestModalContent">
-        <h2>Select Biomass to Harvest</h2>
+        <h2>Start Harvest</h2>
+        <div>
+          <label for="harvestPenSelect">Pen:</label>
+          <select id="harvestPenSelect"></select>
+        </div>
         <div>Max: <span id="harvestMax">0</span> kg</div>
         <input type="number" id="harvestAmount" min="0" step="0.01">
-        <button onclick="confirmHarvest()">Harvest</button>
+        <button onclick="confirmHarvest()">Start Harvest</button>
         <button onclick="closeHarvestModal()">Cancel</button>
       </div>
     </div>

--- a/models.js
+++ b/models.js
@@ -30,13 +30,15 @@ export class Pen {
     fishCount = 0,
     averageWeight = 0,
     bargeIndex = 0,
-    feeder = null
+    feeder = null,
+    locked = false
   } = {}) {
     this.species = species;
     this.fishCount = fishCount;
     this.averageWeight = averageWeight;
     this.bargeIndex = bargeIndex;
     this.feeder = feeder;
+    this.locked = locked;
   }
 }
 
@@ -87,5 +89,6 @@ export class Vessel {
     Object.defineProperty(this, 'harvestTimeout', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestProgress', { value: 0, writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestFishBuffer', { value: 0, writable: true, enumerable: false });
+    Object.defineProperty(this, 'harvestingPenIndex', { value: null, writable: true, enumerable: false });
   }
 }


### PR DESCRIPTION
## Summary
- add locked flag to pens
- expose harvesting progress on vessel cards
- implement vessel harvest modal with pen list and dynamic max amount
- disable actions on locked pens
- persist new properties in save data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68810c6e948083299df0c23504216d30