### PR TITLE
Fix progress bar fill height

### DIFF
--- a/style.css
+++ b/style.css
@@ -422,6 +422,8 @@ button:active {
   background: var(--accent);
   height: 100%;
   width: 0;
+  display: block;
+  border-radius: inherit;
   transition: width 0.3s;
 }
 .bargeCard h2 {


### PR DESCRIPTION
## Summary
- ensure `.progress` element fills full height of `.progressBar` by using `display: block` and inheriting border radius

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688122928fc083298d26de99d309a089