### PR TITLE
Move barge upgrades to modal

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -267,6 +267,13 @@ function closeMoveModal(){
   document.getElementById('moveModal').classList.remove('visible');
 }
 
+function openBargeUpgradeModal(){
+  document.getElementById('bargeUpgradeModal').classList.add('visible');
+}
+function closeBargeUpgradeModal(){
+  document.getElementById('bargeUpgradeModal').classList.remove('visible');
+}
+
 function moveVesselTo(type, idx){
   const vessel = state.vessels[state.currentVesselIndex];
   let destName;
@@ -772,4 +779,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState  };
+export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, getTimeState  };

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             <div id="bargeHousingInfo"></div>
             <button class="staff-button" onclick="upgradeStaffHousing()">Upgrade Housing</button>
             <button onclick="buyMaxFeed()">Refill Feed</button>
-            <button onclick="toggleSection('bargeOptions')">Barge Upgrades</button>
+            <button onclick="openBargeUpgradeModal()">Barge Upgrades</button>
           </div>
           <div id="staffCard" class="staffCard">
             <h2>Staffing</h2>
@@ -101,13 +101,6 @@
         <button onclick="buyMaxFeed()">Buy Max</button>
       </div>
 
-      <div class="shopSection" onclick="toggleSection('bargeOptions')">Barge Upgrades</div>
-      <div id="bargeOptions" class="shopSection-content">
-        <button onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
-        <button onclick="buyNewBarge()">Buy Barge</button>
-        <button onclick="upgradeBarge()">Upgrade Barge</button>
-        <button onclick="buyNewPen()">+ Pen</button>
-      </div>
 
 
 
@@ -119,10 +112,6 @@
         <button onclick="devAddBiomass()">+10kg Biomass (Pen)</button>
       </div>
 
-      <div id="storageUpgradeInfo"></div>
-      <div id="bargeUpgradeInfo"></div>
-      <div id="bargePurchaseInfo"></div>
-      <div id="penPurchaseInfo"></div>
       <div id="licenseShop"></div>
       <div id="statusMessages"></div>
       </div>
@@ -229,6 +218,21 @@
         <input type="text" id="renameInput">
         <button onclick="confirmRename()">Rename</button>
         <button onclick="closeRenameModal()">Cancel</button>
+      </div>
+    </div>
+
+    <div id="bargeUpgradeModal">
+      <div id="bargeUpgradeModalContent">
+        <h2>Barge Upgrades</h2>
+        <button onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
+        <button onclick="upgradeBarge()">Upgrade Barge</button>
+        <button onclick="buyNewPen()">+ Pen</button>
+        <button onclick="buyNewBarge()">Buy Barge</button>
+        <div id="storageUpgradeInfo"></div>
+        <div id="bargeUpgradeInfo"></div>
+        <div id="bargePurchaseInfo"></div>
+        <div id="penPurchaseInfo"></div>
+        <button onclick="closeBargeUpgradeModal()">Close</button>
       </div>
     </div>
   <script type="module" src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -206,7 +206,8 @@ button:active {
 #vesselHarvestModal,
 #sellModal,
 #moveModal,
-#renameModal {
+#renameModal,
+#bargeUpgradeModal {
   position: fixed;
   top: 0;
   left: 0;
@@ -225,7 +226,8 @@ button:active {
 #vesselHarvestModal.visible,
 #sellModal.visible,
 #moveModal.visible,
-#renameModal.visible {
+#renameModal.visible,
+#bargeUpgradeModal.visible {
   display: flex;
 }
 
@@ -235,7 +237,8 @@ button:active {
 #vesselHarvestModalContent,
 #sellModalContent,
 #moveModalContent,
-#renameModalContent {
+#renameModalContent,
+#bargeUpgradeModalContent {
   background: var(--modal-bg);
   color: var(--text-light);
   padding: 20px;


### PR DESCRIPTION
## Summary
- relocate barge upgrade options into a modal
- open modal from barge card rather than sidebar
- remove barge upgrade section from shop
- support new modal in styles and actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688134ac993483298afb973f94e14baf