### PR TITLE
Fix upgrade modal message overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,6 +223,7 @@
     <div id="bargeUpgradeModal">
       <div id="bargeUpgradeModalContent">
         <h2>Barge Upgrades</h2>
+        <div id="bargeUpgradeMessage" class="barge-alert" style="display:none"></div>
         <button class="staff-button" onclick="buyFeedStorageUpgrade()">Upgrade Storage</button>
         <button class="staff-button" onclick="upgradeBarge()">Upgrade Barge</button>
         <button class="staff-button" onclick="upgradeStaffHousing()">Upgrade Housing</button>

--- a/style.css
+++ b/style.css
@@ -246,6 +246,13 @@ button:active {
   text-align: center;
   width: 300px;
 }
+
+#bargeUpgradeMessage {
+  margin-bottom: 8px;
+  color: #e74c3c;
+  font-weight: bold;
+  display: none;
+}
 #sidebarContent,
 #sidebar .panel {
   scrollbar-width: none; /* Firefox */

--- a/ui.js
+++ b/ui.js
@@ -394,7 +394,20 @@ function setupMapInteractions(){
 }
 
 // --- MODALS ---
-function openModal(msg){ document.getElementById('modalText').innerText=msg; document.getElementById('modal').classList.add('visible'); }
+function openModal(msg){
+  const bargeModal = document.getElementById('bargeUpgradeModal');
+  if(bargeModal && bargeModal.classList.contains('visible')){
+    const alertEl = document.getElementById('bargeUpgradeMessage');
+    if(alertEl){
+      alertEl.textContent = msg;
+      alertEl.style.display = 'block';
+      setTimeout(()=>{ alertEl.style.display = 'none'; }, 3000);
+    }
+    return;
+  }
+  document.getElementById('modalText').innerText = msg;
+  document.getElementById('modal').classList.add('visible');
+}
 function closeModal(){ document.getElementById('modal').classList.remove('visible'); }
 function openRestockModal(){
   const site = state.sites[state.currentSiteIndex];


### PR DESCRIPTION
## Summary
- add internal alert area for the Barge Upgrade modal
- style upgrade alert
- route openModal messages to the upgrade alert when the Barge Upgrade modal is open

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68813f762ae48329848ce177c069aa6a