### PR TITLE
Improve market report UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,7 @@
       </div>
     </div>
     <div id="marketReportModal">
+      <!-- Market tables and future graph placeholder will be injected into this container -->
       <div id="marketReportContent" class="market-report"></div>
       <button onclick="closeMarketReport()">Close</button>
     </div>

--- a/style.css
+++ b/style.css
@@ -240,14 +240,22 @@ button:active {
 #sellModalContent,
 #moveModalContent,
 #renameModalContent,
-#bargeUpgradeModalContent,
-#marketReportContent {
+#bargeUpgradeModalContent {
   background: var(--modal-bg);
   color: var(--text-light);
   padding: 20px;
   border-radius: 10px;
   text-align: center;
   width: 300px;
+}
+
+#marketReportContent {
+  background: var(--modal-bg);
+  color: var(--text-light);
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  width: 600px;
 }
 
 #bargeUpgradeMessage {
@@ -640,6 +648,44 @@ button:active {
 .logisticsCard,
 .tipsCard {
   animation: fadeIn 0.3s ease;
+}
+
+/* Market report styles */
+.market-section {
+  margin-bottom: 20px;
+}
+
+.market-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 8px;
+}
+
+.market-table th,
+.market-table td {
+  border: 1px solid var(--bg-button);
+  padding: 4px 6px;
+  font-size: 14px;
+}
+
+.market-table th {
+  background: var(--bg-button);
+}
+
+.trend-up {
+  color: #2ecc71;
+}
+
+.trend-down {
+  color: #e74c3c;
+}
+
+.chart-placeholder {
+  background: var(--bg-darker);
+  color: var(--text-muted);
+  padding: 6px;
+  border-radius: 6px;
+  font-size: 12px;
 }
 
 /* Responsive layout */

--- a/ui.js
+++ b/ui.js
@@ -539,22 +539,70 @@ function sellCargo(idx){
 
 function openMarketReport(){
   const container = document.getElementById('marketReportContent');
-  container.innerHTML = '';
+  container.innerHTML = '<h2>Market Report</h2>';
+
   markets.forEach(m => {
-    const div = document.createElement('div');
+    const section = document.createElement('div');
+    section.classList.add('market-section');
+
     const h = document.createElement('h3');
     h.innerText = m.name;
-    div.appendChild(h);
-    const ul = document.createElement('ul');
+    section.appendChild(h);
+
+    const table = document.createElement('table');
+    table.classList.add('market-table');
+
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Species</th><th>Price</th><th>Change</th><th>Last 5</th></tr>';
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
     for(const sp in m.prices){
-      const li = document.createElement('li');
-      const hist = m.priceHistory[sp].map(p=>p.toFixed(2)).join(' -> ');
-      li.innerText = `${state.capitalizeFirstLetter(sp)}: $${m.prices[sp].toFixed(2)} (${hist})`;
-      ul.appendChild(li);
+      const row = document.createElement('tr');
+
+      const nameCell = document.createElement('td');
+      nameCell.innerText = state.capitalizeFirstLetter(sp);
+
+      const price = m.prices[sp];
+      const history = m.priceHistory[sp];
+      const prevPrice = history[history.length - 2] || price;
+      const delta = price - prevPrice;
+      const recent = history.slice(-5).map(p=>p.toFixed(2)).join(', ');
+      const high = Math.max(...history.slice(-7));
+      const low = Math.min(...history.slice(-7));
+
+      const priceCell = document.createElement('td');
+      priceCell.innerText = `$${price.toFixed(2)}`;
+      if(price === high) priceCell.innerText += ' ▲';
+      if(price === low) priceCell.innerText += ' ▼';
+
+      const changeCell = document.createElement('td');
+      const arrow = delta > 0 ? '↑' : delta < 0 ? '↓' : '→';
+      changeCell.innerText = `${delta >= 0 ? '+' : ''}${delta.toFixed(2)} ${arrow}`;
+      changeCell.className = delta > 0 ? 'trend-up' : delta < 0 ? 'trend-down' : '';
+
+      const histCell = document.createElement('td');
+      histCell.innerText = recent;
+      histCell.classList.add('history-cell');
+
+      row.appendChild(nameCell);
+      row.appendChild(priceCell);
+      row.appendChild(changeCell);
+      row.appendChild(histCell);
+      tbody.appendChild(row);
     }
-    div.appendChild(ul);
-    container.appendChild(div);
+
+    table.appendChild(tbody);
+    section.appendChild(table);
+
+    const placeholder = document.createElement('div');
+    placeholder.classList.add('chart-placeholder');
+    placeholder.innerText = 'Graph coming soon...';
+    section.appendChild(placeholder);
+
+    container.appendChild(section);
   });
+
   document.getElementById('marketReportModal').classList.add('visible');
 }
 


### PR DESCRIPTION
## Summary
- redesign Market Report modal layout into tables
- show price trends with arrows and highlight weekly highs/lows
- display recent price history concisely
- enlarge Market Report modal and add styles
- add placeholder for future price graph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688146010cb083298849536417a5bc69