### PR TITLE
Convert Market Report to full page

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,10 +237,10 @@
         <button class="staff-button" onclick="closeBargeUpgradeModal()">Close</button>
       </div>
     </div>
-    <div id="marketReportModal">
+    <div id="marketReportPage" class="market-report-page">
+      <button id="closeMarketReportBtn" class="close-report-btn" onclick="closeMarketReport()">Back</button>
       <!-- Market tables and future graph placeholder will be injected into this container -->
       <div id="marketReportContent" class="market-report"></div>
-      <button onclick="closeMarketReport()">Close</button>
     </div>
   <script type="module" src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -207,8 +207,7 @@ button:active {
 #sellModal,
 #moveModal,
 #renameModal,
-#bargeUpgradeModal,
-#marketReportModal {
+#bargeUpgradeModal {
   position: fixed;
   top: 0;
   left: 0;
@@ -228,8 +227,7 @@ button:active {
 #sellModal.visible,
 #moveModal.visible,
 #renameModal.visible,
-#bargeUpgradeModal.visible,
-#marketReportModal.visible {
+#bargeUpgradeModal.visible {
   display: flex;
 }
 
@@ -249,13 +247,43 @@ button:active {
   width: 300px;
 }
 
-#marketReportContent {
-  background: var(--modal-bg);
+#marketReportPage {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: var(--bg-darker);
   color: var(--text-light);
+  overflow-y: auto;
   padding: 20px;
-  border-radius: 10px;
-  text-align: center;
-  width: 600px;
+  display: none;
+  z-index: 900;
+}
+
+#marketReportPage.visible {
+  display: block;
+}
+
+#marketReportContent {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.market-timestamp {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.close-report-btn {
+  background: var(--btn-main);
+  color: var(--text-dark);
+  border: none;
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-bottom: 10px;
 }
 
 #bargeUpgradeMessage {

--- a/ui.js
+++ b/ui.js
@@ -541,6 +541,12 @@ function openMarketReport(){
   const container = document.getElementById('marketReportContent');
   container.innerHTML = '<h2>Market Report</h2>';
 
+  const ts = state.getTimeState ? state.getTimeState() : { totalDaysElapsed: 0 };
+  const timestamp = document.createElement('div');
+  timestamp.className = 'market-timestamp';
+  timestamp.innerText = `Prices last updated: Day ${ts.totalDaysElapsed}`;
+  container.appendChild(timestamp);
+
   markets.forEach(m => {
     const section = document.createElement('div');
     section.classList.add('market-section');
@@ -603,11 +609,11 @@ function openMarketReport(){
     container.appendChild(section);
   });
 
-  document.getElementById('marketReportModal').classList.add('visible');
+  document.getElementById('marketReportPage').classList.add('visible');
 }
 
 function closeMarketReport(){
-  document.getElementById('marketReportModal').classList.remove('visible');
+  document.getElementById('marketReportPage').classList.remove('visible');
 }
 
 // --- PURCHASES & ACTIONS ---


### PR DESCRIPTION
## Summary
- replace modal with fullscreen Market Report page
- create scrolling layout and back button
- add timestamp when prices were last updated
- tweak styles for new page layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814a9385e083298a504b1984780c9d