### PR TITLE
Fix mobile overflow for Market Report

### DIFF
--- a/style.css
+++ b/style.css
@@ -251,11 +251,13 @@ button:active {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
   background: var(--bg-darker);
   color: var(--text-light);
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 20px;
   display: none;
   z-index: 900;
@@ -277,6 +279,8 @@ button:active {
 }
 
 .close-report-btn {
+  position: sticky;
+  top: 0;
   background: var(--btn-main);
   color: var(--text-dark);
   border: none;
@@ -284,6 +288,7 @@ button:active {
   border-radius: 6px;
   cursor: pointer;
   margin-bottom: 10px;
+  z-index: 10;
 }
 
 #bargeUpgradeMessage {
@@ -687,6 +692,7 @@ button:active {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 8px;
+  table-layout: fixed;
 }
 
 .market-table th,
@@ -706,6 +712,10 @@ button:active {
 
 .trend-down {
   color: #e74c3c;
+}
+
+.history-cell {
+  word-break: break-word;
 }
 
 .chart-placeholder {

--- a/ui.js
+++ b/ui.js
@@ -616,10 +616,14 @@ function openMarketReport(){
   });
 
   document.getElementById('marketReportPage').classList.add('visible');
+  document.body.style.overflow = 'hidden';
+  document.documentElement.style.overflow = 'hidden';
 }
 
 function closeMarketReport(){
   document.getElementById('marketReportPage').classList.remove('visible');
+  document.body.style.overflow = '';
+  document.documentElement.style.overflow = '';
 }
 
 // --- PURCHASES & ACTIONS ---


### PR DESCRIPTION
## Summary
- ensure the market report fills the viewport without causing horizontal scroll
- keep the back button visible with sticky positioning
- allow table cells to wrap and set fixed table layout
- disable background scrolling while the market report is shown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815d08bb088329932ffe50b02f4cea