### PR TITLE
Add inline time controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Call `pauseTime()` to halt all in-game timers and `resumeTime()` to continue.
 While paused, day progression, market prices, vessel travel and other timed
 activities are completely suspended. Resuming simply continues each task from
 the moment it was paused with no time skipped.
+Small play (▶️) and pause (⏸️) icons next to the in-game date let you control
+this without using the console.
 
 ## Getting Started
 No build steps are required. Open `index.html` in any modern web browser to start the game. Everything runs locally in the browser.

--- a/actions.js
+++ b/actions.js
@@ -811,10 +811,12 @@ function resetGame() {
 
 function pauseTime(){
   state.pauseTime();
+  updateDisplay();
 }
 
 function resumeTime(){
   state.resumeTime();
+  updateDisplay();
 }
 
 // site/pen nav

--- a/index.html
+++ b/index.html
@@ -21,7 +21,12 @@
       </div>
       <div class="top-right">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
-        <div><strong>Date:</strong> <span id="dateDisplay">Spring 1, Year 1</span></div>
+        <div>
+          <strong>Date:</strong>
+          <span id="dateDisplay">Spring 1, Year 1</span>
+          <span id="pauseButton" class="time-btn" title="Pause" onclick="pauseTime()">⏸️</span>
+          <span id="playButton" class="time-btn" title="Resume" onclick="resumeTime()">▶️</span>
+        </div>
         <button onclick="openMarketReport()">Market Report</button>
       </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -607,6 +607,12 @@ button:active {
   cursor: pointer;
 }
 
+.time-btn {
+  cursor: pointer;
+  margin-left: 4px;
+  font-size: 16px;
+}
+
 .top-left button:hover, .top-right button:hover {
   background-color: var(--accent);
   color: var(--bg-darker);

--- a/ui.js
+++ b/ui.js
@@ -32,6 +32,17 @@ function updateDisplay(){
   document.getElementById('cashCount').innerText = state.cash.toFixed(2);
   const dateEl = document.getElementById('dateDisplay');
   if(dateEl) dateEl.innerText = getDateString();
+  const playBtn = document.getElementById('playButton');
+  const pauseBtn = document.getElementById('pauseButton');
+  if(playBtn && pauseBtn){
+    if(state.timePaused){
+      playBtn.style.display = 'inline';
+      pauseBtn.style.display = 'none';
+    } else {
+      playBtn.style.display = 'none';
+      pauseBtn.style.display = 'inline';
+    }
+  }
 
   // barge card & feed overview
   const barge = site.barges[state.currentBargeIndex];


### PR DESCRIPTION
## Summary
- confirm pause/resume features via `pauseTime` and `resumeTime`
- add minimal play/pause icons next to date in the top bar
- toggle icons based on time state in the UI
- call `updateDisplay` when pausing/resuming
- document new controls in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815e3df2c08329b8e8cdf52ebc7d9b