### PR TITLE
Update market report timestamp format

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -729,6 +729,7 @@ function saveGame() {
       daysSinceSale: m.daysSinceSale,
       basePrices: m.basePrices
     })),
+    lastMarketUpdate: state.lastMarketUpdateString,
     lastSaved: Date.now(),
     time: {
       totalDaysElapsed: state.totalDaysElapsed,
@@ -778,6 +779,9 @@ function loadGame() {
         state.dayInSeason = obj.time.dayInSeason ?? state.dayInSeason;
         state.seasonIndex = obj.time.seasonIndex ?? state.seasonIndex;
         state.year = obj.time.year ?? state.year;
+      }
+      if(obj.lastMarketUpdate){
+        state.lastMarketUpdateString = obj.lastMarketUpdate;
       }
       if(obj.lastSaved){
         const diff = Date.now() - obj.lastSaved;

--- a/gameState.js
+++ b/gameState.js
@@ -45,6 +45,7 @@ const state = {
 
   statusMessage: '',
   lastOfflineInfo: null,
+  lastMarketUpdateString: 'Spring 1, Year 1',
 };
 
 // Expose read-only accessors for external logic
@@ -71,6 +72,9 @@ function getDateString() {
 }
 
 state.getDateString = getDateString;
+
+// initialize last market update timestamp
+state.lastMarketUpdateString = getDateString();
 
 // ---- Market Pricing ----
 function setupMarketData(){
@@ -111,6 +115,7 @@ state.setupMarketData = setupMarketData;
 state.updateMarketPrices = updateMarketPrices;
 
 function advanceDay() {
+  state.lastMarketUpdateString = getDateString();
   state.totalDaysElapsed++;
   state.dayInSeason++;
   if (state.dayInSeason > state.DAYS_PER_SEASON) {

--- a/ui.js
+++ b/ui.js
@@ -130,6 +130,8 @@ function updateDisplay(){
   if(statusEl) statusEl.innerText = state.statusMessage;
   const tipsEl = document.getElementById('operationalTips');
   if(tipsEl) tipsEl.innerText = state.statusMessage || 'All systems nominal.';
+  const tsEl = document.querySelector('#marketReportContent .market-timestamp');
+  if(tsEl) tsEl.innerText = `Prices last updated: ${state.lastMarketUpdateString}`;
 }
 
 // harvest preview
@@ -558,10 +560,10 @@ function openMarketReport(){
   const container = document.getElementById('marketReportContent');
   container.innerHTML = '<h2>Market Report</h2>';
 
-  const ts = state.getTimeState ? state.getTimeState() : { totalDaysElapsed: 0 };
   const timestamp = document.createElement('div');
   timestamp.className = 'market-timestamp';
-  timestamp.innerText = `Prices last updated: Day ${ts.totalDaysElapsed}`;
+  const dateStr = state.lastMarketUpdateString || getDateString();
+  timestamp.innerText = `Prices last updated: ${dateStr}`;
   container.appendChild(timestamp);
 
   markets.forEach(m => {


### PR DESCRIPTION
## Summary
- track `lastMarketUpdateString` in game state
- persist last market update in save data
- display formatted date on Market Report page
- refresh the timestamp when the day advances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815fd530488329a217a9aae174dd69