### PR TITLE
Add market price trend graphs

### DIFF
--- a/style.css
+++ b/style.css
@@ -692,6 +692,7 @@ button:active {
 /* Market report styles */
 .market-section {
   margin-bottom: 20px;
+  overflow-x: auto;
 }
 
 .market-table {
@@ -738,6 +739,28 @@ button:active {
   padding: 6px;
   border-radius: 6px;
   font-size: 12px;
+}
+
+.market-chart {
+  width: 100%;
+  height: 150px;
+  display: block;
+}
+
+.market-legend {
+  font-size: 12px;
+  margin-bottom: 8px;
+  text-align: center;
+}
+.legend-item {
+  margin-right: 8px;
+}
+.legend-color {
+  display: inline-block;
+  width: 12px;
+  height: 4px;
+  margin-right: 4px;
+  vertical-align: middle;
 }
 
 /* Responsive layout */


### PR DESCRIPTION
## Summary
- plot price history graphs for each market
- show color-coded legend under each chart
- keep charts updated while the report is open

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688165f0c114832988f3e553d413abf4