### PR TITLE
Fix shipyard overlay and button

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -29,7 +29,9 @@ import {
   closeSellModal,
   sellCargo,
   openMarketReport,
-  closeMarketReport
+  closeMarketReport,
+  openShipyard as uiOpenShipyard,
+  closeShipyard as uiCloseShipyard
 } from "./ui.js";
 
 function buyFeed(amount=20){
@@ -280,10 +282,10 @@ function closeBargeUpgradeModal(){
 }
 
 function openShipyard(){
-  ui.openShipyard();
+  uiOpenShipyard();
 }
 function closeShipyard(){
-  ui.closeShipyard();
+  uiCloseShipyard();
 }
 function buyShipyardVessel(idx){
   const item = state.shipyardInventory[idx];

--- a/index.html
+++ b/index.html
@@ -245,9 +245,9 @@
     </div>
     <div id="shipyardModal">
       <div id="shipyardModalContent">
+        <button class="close-shipyard-btn" onclick="closeShipyard()">Back</button>
         <h2>Shipyard</h2>
         <div id="shipyardList"></div>
-        <button onclick="closeShipyard()">Close</button>
       </div>
     </div>
     <div id="marketReportPage" class="market-report-page">

--- a/style.css
+++ b/style.css
@@ -207,8 +207,7 @@ button:active {
 #sellModal,
 #moveModal,
 #renameModal,
-#bargeUpgradeModal,
-#shipyardModal {
+#bargeUpgradeModal {
   position: fixed;
   top: 0;
   left: 0;
@@ -221,6 +220,22 @@ button:active {
   z-index: 1000;
 }
 
+#shipyardModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  background: var(--bg-darker);
+  color: var(--text-light);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 20px;
+  display: none;
+  z-index: 900;
+}
+
 #modal.visible,
 #restockModal.visible,
 #harvestModal.visible,
@@ -228,9 +243,12 @@ button:active {
 #sellModal.visible,
 #moveModal.visible,
 #renameModal.visible,
-#bargeUpgradeModal.visible,
-#shipyardModal.visible {
+#bargeUpgradeModal.visible {
   display: flex;
+}
+
+#shipyardModal.visible {
+  display: block;
 }
 
 #modalContent,
@@ -240,14 +258,18 @@ button:active {
 #sellModalContent,
 #moveModalContent,
 #renameModalContent,
-#bargeUpgradeModalContent,
-#shipyardModalContent {
+#bargeUpgradeModalContent {
   background: var(--modal-bg);
   color: var(--text-light);
   padding: 20px;
   border-radius: 10px;
   text-align: center;
   width: 300px;
+}
+
+#shipyardModalContent {
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .shipyard-row {
@@ -289,6 +311,19 @@ button:active {
 }
 
 .close-report-btn {
+  position: sticky;
+  top: 0;
+  background: var(--btn-main);
+  color: var(--text-dark);
+  border: none;
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-bottom: 10px;
+  z-index: 10;
+}
+
+.close-shipyard-btn {
   position: sticky;
   top: 0;
   background: var(--btn-main);

--- a/ui.js
+++ b/ui.js
@@ -531,9 +531,13 @@ function openShipyard(){
     list.appendChild(row);
   });
   document.getElementById('shipyardModal').classList.add('visible');
+  document.body.style.overflow = 'hidden';
+  document.documentElement.style.overflow = 'hidden';
 }
 function closeShipyard(){
   document.getElementById('shipyardModal').classList.remove('visible');
+  document.body.style.overflow = '';
+  document.documentElement.style.overflow = '';
 }
 
 function sellCargo(idx){


### PR DESCRIPTION
## Summary
- style shipyard overlay like the market report page
- lock scrolling when shipyard is visible
- fix actions to import shipyard helpers correctly
- add a sticky Back button to shipyard modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688172d79e548329b4fc84ee332faafa