### PR TITLE
Fix missing openCustomBuild function

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -30,7 +30,8 @@ import {
   confirmVesselHarvest,
   openSellModal,
   closeSellModal,
-  sellCargo
+  sellCargo,
+  openCustomBuild
 } from "./ui.js";
 
 function buyFeed(amount=20){
@@ -742,4 +743,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState  };
+export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState, openCustomBuild };

--- a/ui.js
+++ b/ui.js
@@ -388,6 +388,11 @@ function closeSellModal(){
   document.getElementById('sellModal').classList.remove('visible');
 }
 
+function openCustomBuild(){
+  // Placeholder for shipyard custom build interface
+  openModal('Custom build feature coming soon!');
+}
+
 function sellCargo(idx){
   const vessel = state.vessels[state.currentVesselIndex];
   if(vessel.currentBiomassLoad<=0) return openModal('No biomass to sell.');
@@ -444,5 +449,6 @@ export {
   confirmVesselHarvest,
   openSellModal,
   closeSellModal,
+  openCustomBuild,
   sellCargo
 };


### PR DESCRIPTION
## Summary
- add placeholder `openCustomBuild` UI handler
- re-export `openCustomBuild` from `actions.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688186d66f8083299558711fff3679bd