### PR TITLE
Improve shipyard layout styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,9 +247,9 @@
       <div id="shipyardModalContent">
         <button class="close-shipyard-btn" onclick="closeShipyard()">Back</button>
         <h2>Shipyard</h2>
-        <div id="shipyardList"></div>
-        <button id="openCustomBuildBtn" onclick="openCustomBuild()">Custom Build</button>
-        <div id="customBuildPage" class="custom-build-page" style="display:none">
+        <div id="shipyardList" class="shipyard-list"></div>
+        <button id="openCustomBuildBtn" class="shipyard-main-btn" onclick="openCustomBuild()">Custom Build</button>
+        <div id="customBuildPage" class="custom-build-page shipyard-card" style="display:none">
           <button class="close-shipyard-btn" onclick="backToShipyardList()">Back</button>
           <h3>Custom Build</h3>
           <div>
@@ -262,6 +262,7 @@
             <input type="text" id="buildNameInput">
           </div>
           <div>Cost: $<span id="buildCost"></span></div>
+          <div id="buildLockMessage" class="lock-message" style="display:none"></div>
           <button onclick="confirmCustomBuild()">Purchase</button>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -272,19 +272,69 @@ button:active {
   margin: 0 auto;
 }
 
-.shipyard-row {
-  margin-bottom: 8px;
+#shipyardList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 20px;
 }
-.shipyard-row button {
-  margin-left: 10px;
+
+.shipyard-card {
+  background: var(--bg-panel);
+  border-radius: 10px;
+  padding: 12px;
+  box-shadow: 0 0 4px var(--shadow-light);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+}
+
+.shipyard-card h4 {
+  margin: 0 0 6px;
+  font-size: 16px;
+  color: var(--accent);
+}
+
+.shipyard-attr,
+.shipyard-price {
+  font-size: 14px;
+  margin: 2px 0;
+}
+
+.shipyard-card button {
+  width: 100%;
+  margin-top: 8px;
+  padding: 6px 8px;
+  font-size: 13px;
+  background-color: var(--bg-button);
+  color: var(--text-light);
+  border-radius: 6px;
+  border: none;
+}
+
+.shipyard-card button:hover {
+  background-color: var(--accent);
+  color: var(--bg-darker);
+}
+
+.shipyard-main-btn {
+  margin-top: 12px;
+}
+
+.lock-message {
+  color: #e74c3c;
+  font-size: 14px;
+  margin-top: 6px;
 }
 
 .custom-build-page {
-  margin-top: 10px;
-  padding: 10px;
+  margin-top: 20px;
+  padding: 12px;
   background: var(--bg-panel);
-  border-radius: 8px;
+  border-radius: 10px;
+  box-shadow: 0 0 4px var(--shadow-light);
   display: none;
+  border-top: 1px solid var(--bg-button);
 }
 
 #marketReportPage {

--- a/ui.js
+++ b/ui.js
@@ -9,6 +9,7 @@ import {
   vesselTiers,
   markets,
   vesselClasses,
+  vesselUnlockDays,
   CUSTOM_BUILD_MARKUP
 } from "./data.js";
 import state, {
@@ -520,10 +521,14 @@ function openShipyard(){
   list.innerHTML = '';
   state.shipyardInventory.forEach((v, idx)=>{
     const row = document.createElement('div');
-    row.className = 'shipyard-row';
-    row.innerHTML = `<strong>${v.name}</strong> - ${vesselClasses[v.class].name} `+
-      `| Cap ${v.cargoCapacity}kg | Speed ${v.speed} | Slots ${v.upgradeSlots} `+
-      `| $${v.cost}`;
+    row.className = 'shipyard-row shipyard-card';
+    row.innerHTML = `
+      <h4 class="vessel-name">${v.name}</h4>
+      <div class="shipyard-attr">Class: ${vesselClasses[v.class].name}</div>
+      <div class="shipyard-attr">Cap ${v.cargoCapacity}kg</div>
+      <div class="shipyard-attr">Speed ${v.speed}</div>
+      <div class="shipyard-attr">Slots ${v.upgradeSlots}</div>
+      <div class="shipyard-price">$${v.cost}</div>`;
     const btn = document.createElement('button');
     btn.innerText = 'Buy';
     btn.onclick = ()=>buyShipyardVessel(idx);
@@ -569,6 +574,15 @@ function updateCustomBuildStats(){
   document.getElementById('buildCost').innerText = cost;
   document.getElementById('buildStats').innerText =
     `Cap ${data.baseCapacity}kg | Speed ${data.baseSpeed} | Slots ${data.slots}`;
+  const msgEl = document.getElementById('buildLockMessage');
+  const req = vesselUnlockDays[cls] || 0;
+  if(state.totalDaysElapsed < req && cls !== 'skiff'){
+    msgEl.style.display = 'block';
+    msgEl.innerText = `Locked until Day ${req}`;
+  } else {
+    msgEl.style.display = 'none';
+    msgEl.innerText = '';
+  }
 }
 
 function sellCargo(idx){


### PR DESCRIPTION
## Summary
- give the shipyard listing a grid and card style
- make the custom build page share the shipyard card styling
- show lock message in custom build when vessel class is locked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818dd0471c8329b84570444a737198