### PR TITLE
Fix header overlap and improve desktop layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,7 @@
   --shadow-medium: #0006;
   --black: #000;
   --font-main: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+  --header-height: 80px;
 }
 
 /* Global Styles */
@@ -29,14 +30,21 @@ body {
   color: var(--text-light);
   text-align: center;
   margin: 0;
-  padding-top: 70px;
+  padding-top: var(--header-height);
   overflow-x: hidden; /* prevent horizontal scroll on mobile */
 }
 .container {
-  max-width: 900px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 16px;
   transition: transform 0.3s ease;
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1200px;
+    padding: 0 20px;
+  }
 }
 button {
   margin: 8px;
@@ -562,6 +570,18 @@ button:active {
   align-items: stretch;
 }
 
+@media (min-width: 900px) {
+  .cardContainer {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .cardContainer > div {
+    flex: 1 1 250px;
+    max-width: none;
+    margin: 0;
+  }
+}
+
 .logisticsCard, .tipsCard {
   background: var(--bg-panel);
   border-radius: 10px;
@@ -672,6 +692,7 @@ button:active {
   top: 0;
   left: 0;
   right: 0;
+  min-height: var(--header-height);
   background: var(--bg-panel);
   box-shadow: 0 2px 6px var(--shadow-medium);
   z-index: 100;
@@ -683,7 +704,7 @@ button:active {
   align-items: center;
   padding: 12px 16px;
   margin: 0 auto;
-  max-width: 900px;
+  max-width: 1200px;
   color: var(--text-light);
 }
 
@@ -746,6 +767,8 @@ button:active {
 #rightSidebar {
   flex: 1;
   min-width: 260px;
+  display: flex;
+  flex-direction: column;
 }
 
 #shop.shopPanel {
@@ -874,5 +897,6 @@ button:active {
   #rightSidebar {
     min-width: unset;
     width: 100%;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- tweak global layout variables and add `--header-height`
- ensure body padding uses the header height
- expand container width on larger screens
- refine header styles and top bar max width
- enable flexible card layout on desktops
- make right sidebar flexible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818f78fba48329a4d2377c2beec412