### PR TITLE
Improve README and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Aquaculture Empire
 
-Aquaculture Empire is a small browser-based aquaculture management game written in plain HTML, CSS and JavaScript. It lets you run multiple fish farming sites, feed and harvest pens and purchase upgrades without needing any server side components.
+Aquaculture Empire is a lightweight browser-based aquaculture management game. Everything runs locally in your browser using plain HTML, CSS and JavaScript. You can operate multiple farming sites, hire staff, upgrade equipment and grow your business without any server side dependencies.
+
+![Screenshot Placeholder](docs/screenshot.png)
+
+The most up-to-date build is available on **GitHub Pages**, so you can play online or deploy your own fork with zero server setup.
 
 ## Features
 - Manage one or more farming sites. Each site has a barge with feed capacity and a number of pens for raising fish.
@@ -30,14 +34,37 @@ Several read-only time values are exposed on the global `window` object:
 You can also call `getTimeState()` to retrieve these values as an object for
 use in mods or custom event hooks.
 
-## Getting Started
-No build steps are required. Open `index.html` in any modern web browser to start the game. Everything runs locally in the browser.
+## Quickstart
+1. Clone or fork the repository:
+   ```bash
+   git clone https://github.com/yourusername/AquacultureEmpire.git
+   cd AquacultureEmpire
+   ```
+2. (Optional) launch a simple local server to test changes:
+   ```bash
+   python3 -m http.server
+   ```
+   Then open your browser at [http://localhost:8000](http://localhost:8000).
+3. You can also deploy directly to **GitHub Pages**. The latest build of this game is hosted there, so no self‑hosting is required.
 
-## File Overview
+## Module Breakdown
 - `index.html` – markup for the sidebar, top bar and modal dialogs.
-- `script.js` – game logic including purchases, feeding, harvesting and UI updates.
-- `data.js` – contains constants for species, upgrades and map locations.
-- `models.js` – simple ES6 classes for Barges, Pens, Sites and Vessels.
 - `style.css` – minimal styling for layout and components.
+- `script.js` – entry point that wires everything together and sets up the auto-save timer.
+- `actions.js` – handles user actions such as buying feed, upgrading equipment, saving and simulating offline progress.
+- `ui.js` – updates DOM elements, renders the map and manages all modal dialogs.
+- `gameState.js` – central state container and time system.
+- `data.js` – constants for species, upgrades, barges, vessels and map locations.
+- `models.js` – simple ES6 classes representing Barges, Pens, Sites and Vessels.
 
-Feel free to modify `script.js` or `data.js` to tweak starting values, species parameters or upgrade costs.
+Feel free to modify `data.js` or the modules above to tweak starting values, species parameters or upgrade costs.
+
+## Auto Save and Offline Progress
+The game automatically saves to your browser's `localStorage` every 30&nbsp;seconds. When you return, `loadGame()` compares the current time with the last save and uses `simulateOfflineProgress()` to advance the simulation in one‑minute steps. A modal dialog shows how many in‑game days passed and how much feed was consumed while you were away.
+
+## Contributing
+Contributions are welcome! Please check the repository's `AGENTS.md` (if present)
+for any project-specific guidelines before submitting a pull request.
+
+## License
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add MIT license file
- update README with fuller intro and screenshot placeholder
- document quickstart steps
- explain module breakdown and auto-save system
- mention AGENTS.md for contributors
- note GitHub Pages hosting and deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881955c13448329a1eaae1ee66f98ac