### PR TITLE
Improve mobile layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,18 @@ import * as actions from './actions.js';
 
 Object.assign(window, actions);
 
+function adjustHeaderPadding(){
+  const header = document.getElementById('topHeader');
+  if(header){
+    const height = header.offsetHeight;
+    document.documentElement.style.setProperty('--header-height', height + 'px');
+  }
+}
+
+window.addEventListener('resize', adjustHeaderPadding);
+
 document.addEventListener('DOMContentLoaded', () => {
+  adjustHeaderPadding();
   actions.loadGame();
   ui.updateDisplay();
   ui.setupMapInteractions();

--- a/style.css
+++ b/style.css
@@ -281,13 +281,11 @@ button:active {
 }
 
 #shipyardList {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 16px;
-  justify-content: center;
+  justify-items: center;
   margin-bottom: 20px;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .shipyard-card {
@@ -298,9 +296,9 @@ button:active {
   text-align: left;
   display: flex;
   flex-direction: column;
-  max-width: 360px;
+  max-width: 90vw;
   width: 100%;
-  margin: 0 auto;
+  margin: 0 auto 16px;
 }
 
 .shipyard-card .vessel-name {
@@ -565,11 +563,11 @@ button:active {
   background: var(--bg-panel);
   border-radius: 10px;
   padding: 16px;
-  margin: 0;
+  margin: 0 0 16px;
   color: var(--text-light);
   box-shadow: 0 0 4px var(--shadow-light);
-  max-width: 250px;
-  flex: 0 0 250px;
+  max-width: 90vw;
+  flex: 1 1 250px;
   transition: transform 0.2s, box-shadow 0.2s;
 }
 .vesselCard.placeholder { opacity: 0.6; }
@@ -815,10 +813,10 @@ button:active {
 
 .vesselGrid {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
-  overflow-x: auto;
+  justify-content: center;
   padding: 10px 0;
-  -webkit-overflow-scrolling: touch;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- dynamically set padding based on header height
- make shipyard vessel cards and grid responsive
- wrap vessel cards in vessel grid for small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a37bc2388329adb84fdbcfa3c920