### PR TITLE
Add slider-based feed purchase UI

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -36,7 +36,11 @@ import {
   closeShipyard as uiCloseShipyard,
   openCustomBuild as uiOpenCustomBuild,
   backToShipyardList as uiBackToShipyardList,
-  updateCustomBuildStats as uiUpdateCustomBuildStats
+  updateCustomBuildStats as uiUpdateCustomBuildStats,
+  updateFeedPurchaseUI,
+  syncFeedPurchase,
+  confirmBuyFeed,
+  setFeedPurchaseMax
 } from "./ui.js";
 
 function buyFeed(amount=20){
@@ -52,15 +56,6 @@ function buyFeed(amount=20){
   updateDisplay();
 }
 
-function buyMaxFeed(){
-  const site = state.sites[state.currentSiteIndex];
-  const barge = site.barges[state.currentBargeIndex];
-  const maxAffordable = Math.floor(state.cash / state.FEED_COST_PER_KG);
-  const available = barge.feedCapacity - barge.feed;
-  const qty = Math.min(maxAffordable, available);
-  if(qty <= 0) return openModal("Cannot purchase feed right now.");
-  buyFeed(qty);
-}
 function buyFeedStorageUpgrade(){
   const site = state.sites[state.currentSiteIndex];
   const barge = site.barges[state.currentBargeIndex];
@@ -917,4 +912,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, getTimeState, pauseTime, resumeTime };
+export { buyFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax };

--- a/index.html
+++ b/index.html
@@ -39,9 +39,20 @@
         <!-- Status cards -->
         <div id="cardContainer" class="cardContainer">
           <div id="feedOverviewCard" class="logisticsCard">
-            <h2>Feed Storage</h2>
+            <h2>Feed Management</h2>
             <div class="progressBar"><div id="feedProgress" class="progress"></div></div>
             <div><span id="totalFeed">0</span> / <span id="totalFeedCapacity">0</span> kg</div>
+            <div id="feedPurchaseSection" class="feed-purchase">
+              <div class="feed-purchase-row">
+                <input type="range" id="feedPurchaseSlider" min="0" value="0" step="1" oninput="syncFeedPurchase('slider')">
+                <input type="number" id="feedPurchaseInput" min="0" value="0" step="1" oninput="syncFeedPurchase('input')">
+              </div>
+              <div id="feedPurchaseCost">Cost: $0.00</div>
+              <div class="feed-purchase-buttons">
+                <button onclick="confirmBuyFeed()">Buy</button>
+                <button onclick="setFeedPurchaseMax()">Buy Max</button>
+              </div>
+            </div>
           </div>
           <div id="bargeCard" class="bargeCard">
             <h2>Barge Status</h2>
@@ -57,7 +68,6 @@
             <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
             <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
             <div id="bargeHousingInfo"></div>
-            <button class="staff-button" onclick="buyMaxFeed()">Refill Feed</button>
             <button class="staff-button" onclick="openBargeUpgradeModal()">Barge Upgrades</button>
           </div>
           <div id="staffCard" class="staffCard">
@@ -101,11 +111,6 @@
 
     <div id="shop" class="shopPanel">
       <h2>Shop</h2>
-      <div id="feedPurchaseButtons">
-        <button onclick="buyFeed(20)">+20kg Feed</button>
-        <button onclick="buyFeed(100)">+100kg Feed</button>
-        <button onclick="buyMaxFeed()">Buy Max</button>
-      </div>
 
 
 

--- a/style.css
+++ b/style.css
@@ -541,13 +541,44 @@ button:active {
   display: none;
   z-index: 5;
 }
-#feedPurchaseButtons button {
-  display: inline-block;
-}
 #statusMessages {
   margin-top: 10px;
   font-size: 14px;
   color: var(--accent);
+}
+
+/* Feed purchase controls */
+.feed-purchase {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.feed-purchase-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.feed-purchase-row input[type="range"] {
+  flex: 1;
+  min-width: 0;
+}
+.feed-purchase-row input[type="number"] {
+  width: 80px;
+}
+.feed-purchase-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .feed-purchase-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .feed-purchase-buttons {
+    flex-direction: column;
+  }
 }
 .bargeCard {
   background: var(--bg-panel);


### PR DESCRIPTION
## Summary
- overhaul feed purchasing with slider and live cost
- remove old feed buttons
- support new feed purchase functions in UI and export them via actions
- add responsive styles for slider section
- remove legacy refill feed button and rename the feed card to "Feed Management"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881aae6e05c8329adb53cecdd57a220