### PR TITLE
Add species tags UI and pen weight warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
           <div class="stat">Avg Weight: <span class="pen-avg"></span> kg</div>
           <div class="stat">Biomass: <span class="pen-biomass"></span> kg</div>
           <div class="stat">Feeder: <span class="pen-feeder"></span></div>
+          <div class="pen-warning"></div>
           <button class="feed-btn">Feed</button>
           <button class="restock-btn">Restock</button>
           <button class="upgrade-btn">Upgrade Feeder</button>

--- a/style.css
+++ b/style.css
@@ -467,6 +467,21 @@ button:active {
   font-size: 14px;
   margin: 4px 0;
 }
+.pen-warning {
+  font-size: 13px;
+  margin: 4px 0;
+}
+.pen-warning.soft {
+  color: var(--text-muted);
+}
+.pen-warning.critical {
+  color: #e74c3c;
+}
+.species-tags {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
 .penCard button,
 .vesselCard button {
   display: block;


### PR DESCRIPTION
## Summary
- show species tags in license shop and restock options
- sort license shop entries alphabetically
- display weight warnings on pen cards
- style new tag and warning text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881b8938a3083298868054a176c9fbc