### PR TITLE
Add market volatility spikes

### DIFF
--- a/data.js
+++ b/data.js
@@ -60,7 +60,8 @@ export const speciesData = {
     restockCost: 200,
     licenseCost: 0,
     maxWeight: 0.05,
-    tags: ["starter", "fast-grow", "low-margin"]
+    tags: ["starter", "fast-grow", "low-margin"],
+    volatility: 1.2
   },
   salmon: {
     marketPrice: 5,
@@ -70,7 +71,8 @@ export const speciesData = {
     restockCost: 400,
     licenseCost: 500,
     maxWeight: 6,
-    tags: ["standard", "coldwater"]
+    tags: ["standard", "coldwater"],
+    volatility: 1
   },
   tuna: {
     marketPrice: 10,
@@ -80,7 +82,8 @@ export const speciesData = {
     restockCost: 800,
     licenseCost: 1500,
     maxWeight: 20,
-    tags: ["premium", "late-game", "offshore"]
+    tags: ["premium", "late-game", "offshore"],
+    volatility: 1.5
   },
   tilapia: {
     marketPrice: 3.5,
@@ -90,7 +93,8 @@ export const speciesData = {
     restockCost: 150,
     licenseCost: 250,
     maxWeight: 2,
-    tags: ["cheap", "fast-grow", "warmwater"]
+    tags: ["cheap", "fast-grow", "warmwater"],
+    volatility: 0.8
   },
   barramundi: {
     marketPrice: 6,
@@ -100,7 +104,8 @@ export const speciesData = {
     restockCost: 350,
     licenseCost: 750,
     maxWeight: 4,
-    tags: ["balanced", "warmwater"]
+    tags: ["balanced", "warmwater"],
+    volatility: 1
   },
   cod: {
     marketPrice: 7.5,
@@ -110,7 +115,8 @@ export const speciesData = {
     restockCost: 500,
     licenseCost: 1000,
     maxWeight: 7,
-    tags: ["stable", "coldwater", "mid-tier"]
+    tags: ["stable", "coldwater", "mid-tier"],
+    volatility: 0.9
   },
   grouper: {
     marketPrice: 12,
@@ -120,7 +126,8 @@ export const speciesData = {
     restockCost: 1000,
     licenseCost: 2000,
     maxWeight: 12,
-    tags: ["premium", "deepwater", "slow-grow"]
+    tags: ["premium", "deepwater", "slow-grow"],
+    volatility: 1.4
   }
 };
 

--- a/gameState.js
+++ b/gameState.js
@@ -91,12 +91,14 @@ function setupMarketData(){
     if(!m.prices) m.prices = {};
     if(!m.priceHistory) m.priceHistory = {};
     if(!m.daysSinceSale) m.daysSinceSale = {};
+    if(!m.volatility) m.volatility = {};
     for(const sp in speciesData){
       const base = speciesData[sp].marketPrice * (m.modifiers[sp]||1);
       if(m.basePrices[sp] === undefined) m.basePrices[sp] = base;
       if(m.prices[sp] === undefined) m.prices[sp] = base;
       if(!Array.isArray(m.priceHistory[sp])) m.priceHistory[sp] = [m.prices[sp]];
       if(m.daysSinceSale[sp] === undefined) m.daysSinceSale[sp] = 0;
+      if(m.volatility[sp] === undefined) m.volatility[sp] = 0;
     }
   });
 }
@@ -106,7 +108,16 @@ function updateMarketPrices(){
     for(const sp in m.prices){
       const base = m.basePrices[sp];
       let price = m.prices[sp];
-      const change = (Math.random()*0.1 - 0.05); // +/-5%
+      if(!m.volatility[sp]) m.volatility[sp] = 0;
+      let momentum = m.volatility[sp] * 0.5;
+      let randomComponent = (Math.random()*0.1 - 0.05);
+      let change = momentum + randomComponent;
+      if(Math.random() < 0.05){
+        change += (Math.random()*0.2 - 0.1);
+      }
+      const volatilityFactor = speciesData[sp].volatility || 1;
+      change *= volatilityFactor;
+      m.volatility[sp] = change;
       price *= (1 + change);
       const min = base * 0.5;
       const max = base * 1.5;


### PR DESCRIPTION
## Summary
- assign a volatility value to each species in `speciesData`
- introduce rare price spikes and a per-species volatility factor during market updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881d440ee948329a8e88ae62bb87b8c