### PR TITLE
Add species badge to pen cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -467,6 +467,7 @@ button:active {
   color: var(--text-light);
   box-shadow: 0 0 4px var(--shadow-light);
   transition: transform 0.2s, box-shadow 0.2s;
+  position: relative;
 }
 .penCard.placeholder {
   opacity: 0.6;
@@ -529,6 +530,26 @@ button:active {
 .vesselCard button:disabled {
   background-color: #555;
   cursor: not-allowed;
+}
+
+.species-badge {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  position: absolute;
+  top: -24px;
+  left: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: grey;
+  overflow: hidden;
+}
+
+.species-badge img {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
 }
 
 .penCard:hover,

--- a/ui.js
+++ b/ui.js
@@ -201,6 +201,20 @@ function renderPenGrid(site){
     card.querySelector('.pen-feeder').textContent = `${capitalizeFirstLetter(feederType)} (Tier ${feederTier})`;
     const warnEl = card.querySelector('.pen-warning');
     updatePenWarning(warnEl, pen);
+
+    const hasFish = pen.species && pen.fishCount > 0;
+    const badge = document.createElement('div');
+    badge.classList.add('species-badge');
+    badge.style.backgroundColor = hasFish ? (speciesColors[pen.species] || '#666') : '#666';
+    if(hasFish){
+      const icon = document.createElement('img');
+      icon.src = 'assets/species-icons/' + pen.species + '.png';
+      icon.alt = pen.species;
+      icon.width = 40;
+      icon.height = 40;
+      badge.appendChild(icon);
+    }
+    card.appendChild(badge);
     card.querySelector('.feed-btn').onclick = () => feedFishPen(idx);
     card.querySelector('.restock-btn').onclick = () => restockPenUI(idx);
     card.querySelector('.upgrade-btn').onclick = () => upgradeFeeder(idx);
@@ -224,6 +238,24 @@ function updatePenCards(site){
     card.querySelector('.pen-feeder').textContent = `${capitalizeFirstLetter(feederType)} (Tier ${feederTier})`;
     const warnEl = card.querySelector('.pen-warning');
     updatePenWarning(warnEl, pen);
+
+    let badge = card.querySelector('.species-badge');
+    if(!badge){
+      badge = document.createElement('div');
+      badge.classList.add('species-badge');
+      card.appendChild(badge);
+    }
+    const hasFish = pen.species && pen.fishCount > 0;
+    badge.style.backgroundColor = hasFish ? (speciesColors[pen.species] || '#666') : '#666';
+    badge.innerHTML = '';
+    if(hasFish){
+      const icon = document.createElement('img');
+      icon.src = 'assets/species-icons/' + pen.species + '.png';
+      icon.alt = pen.species;
+      icon.width = 40;
+      icon.height = 40;
+      badge.appendChild(icon);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add badge styling rules in `style.css`
- position pen cards relative
- render species badge when creating pen cards and update as pens change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a48aa8108329a4527a58af76699d