### PR TITLE
Add species badge overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -533,22 +533,22 @@ button:active {
 }
 
 .species-badge {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
+  /* small notification-style overlay */
+  width: 32px;
+  height: 32px;
   position: absolute;
-  top: -24px;
-  left: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: grey;
+  top: -8px;
+  right: -8px;
+  z-index: 10;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.2);
+  border: 2px solid white;
   overflow: hidden;
 }
 
 .species-badge img {
-  width: 40px;
-  height: 40px;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 

--- a/ui.js
+++ b/ui.js
@@ -203,15 +203,13 @@ function renderPenGrid(site){
     updatePenWarning(warnEl, pen);
 
     const hasFish = pen.species && pen.fishCount > 0;
+    // single badge overlay in the top-right corner
     const badge = document.createElement('div');
     badge.classList.add('species-badge');
-    badge.style.backgroundColor = hasFish ? (speciesColors[pen.species] || '#666') : '#666';
     if(hasFish){
       const icon = document.createElement('img');
       icon.src = 'assets/species-icons/' + pen.species + '.png';
       icon.alt = pen.species;
-      icon.width = 40;
-      icon.height = 40;
       badge.appendChild(icon);
     }
     card.appendChild(badge);
@@ -241,19 +239,17 @@ function updatePenCards(site){
 
     let badge = card.querySelector('.species-badge');
     if(!badge){
+      // create badge once per card
       badge = document.createElement('div');
       badge.classList.add('species-badge');
       card.appendChild(badge);
     }
     const hasFish = pen.species && pen.fishCount > 0;
-    badge.style.backgroundColor = hasFish ? (speciesColors[pen.species] || '#666') : '#666';
     badge.innerHTML = '';
     if(hasFish){
       const icon = document.createElement('img');
       icon.src = 'assets/species-icons/' + pen.species + '.png';
       icon.alt = pen.species;
-      icon.width = 40;
-      icon.height = 40;
       badge.appendChild(icon);
     }
   });


### PR DESCRIPTION
## Summary
- create small circular badge overlay for pen cards
- render the stocked species icon within the badge
- adjust pen card update logic to handle badge
- style the badge as a 32x32 notification circle
- clarify badge is a single overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882c18ec8d48329ae5a993586f96b15