### PR TITLE
Update species badge size and color

### DIFF
--- a/style.css
+++ b/style.css
@@ -533,12 +533,12 @@ button:active {
 }
 
 .species-badge {
-  /* small notification-style overlay */
-  width: 32px;
-  height: 32px;
+  /* notification-style overlay */
+  width: 40px;
+  height: 40px;
   position: absolute;
-  top: -8px;
-  right: -8px;
+  top: -12px;
+  right: -12px;
   z-index: 10;
   border-radius: 50%;
   background-color: rgba(0, 0, 0, 0.2);

--- a/ui.js
+++ b/ui.js
@@ -211,6 +211,9 @@ function renderPenGrid(site){
       icon.src = 'assets/species-icons/' + pen.species + '.png';
       icon.alt = pen.species;
       badge.appendChild(icon);
+      badge.style.backgroundColor = speciesColors[pen.species] || 'rgba(0,0,0,0.2)';
+    } else {
+      badge.style.backgroundColor = 'rgba(0,0,0,0.2)';
     }
     card.appendChild(badge);
     card.querySelector('.feed-btn').onclick = () => feedFishPen(idx);
@@ -251,6 +254,9 @@ function updatePenCards(site){
       icon.src = 'assets/species-icons/' + pen.species + '.png';
       icon.alt = pen.species;
       badge.appendChild(icon);
+      badge.style.backgroundColor = speciesColors[pen.species] || 'rgba(0,0,0,0.2)';
+    } else {
+      badge.style.backgroundColor = 'rgba(0,0,0,0.2)';
     }
   });
 }


### PR DESCRIPTION
## Summary
- make the species badge 25% larger
- update badge position to keep the overlay look
- color each pen's badge using the species color from the market report

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c4ecc4c083298a136af82f4cc964