### PR TITLE
Enhance restock modal UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
       <div id="restockModalContent">
         <h2>Choose Species</h2>
         <div id="restockOptions"></div>
-        <button onclick="closeRestockModal()">Cancel</button>
+        <div class="secondary-btn" onclick="closeRestockModal()">Cancel</div>
       </div>
     </div>
     <div id="harvestModal">

--- a/style.css
+++ b/style.css
@@ -986,6 +986,55 @@ button:active {
   vertical-align: middle;
 }
 
+.species-card {
+  display: flex;
+  gap: 10px;
+  background: rgba(255,255,255,0.05);
+  padding: 10px;
+  border-radius: 6px;
+  align-items: center;
+  cursor: pointer;
+  margin-bottom: 10px;
+}
+
+.species-card.selected {
+  background: rgba(255,255,255,0.15);
+}
+
+.species-icon {
+  width: 48px;
+  height: 48px;
+}
+
+.species-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.species-name {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.species-tags .tag {
+  background: rgba(255,255,255,0.1);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-right: 4px;
+  font-size: 0.75rem;
+  display: inline-block;
+}
+
+.secondary-btn {
+  background: var(--bg-button);
+  color: var(--text-light);
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-block;
+  margin-top: 10px;
+}
+
 /* Responsive layout */
 @media (max-width: 700px) {
   #mainLayout {

--- a/ui.js
+++ b/ui.js
@@ -519,20 +519,43 @@ function openRestockModal(){
   if(pen.fishCount>0){ return openModal("You must harvest the pen before restocking!"); }
   const optionsDiv = document.getElementById('restockOptions');
   optionsDiv.innerHTML = '';
-  site.licenses.forEach(sp=>{
+  site.licenses.forEach(sp => {
     const data = speciesData[sp];
-    const container = document.createElement('div');
-    const btn = document.createElement('button');
-    btn.innerText = `${capitalizeFirstLetter(sp)} ($${data.restockCost})`;
-    btn.onclick = ()=>restockPen(sp);
-    container.appendChild(btn);
-    if(data.tags && data.tags.length){
-      const tagEl = document.createElement('div');
-      tagEl.className = 'species-tags';
-      tagEl.textContent = `Tags: ${data.tags.join(', ')}`;
-      container.appendChild(tagEl);
+    const card = document.createElement('div');
+    card.className = 'species-card';
+    card.onclick = () => {
+      optionsDiv.querySelectorAll('.species-card').forEach(c => c.classList.remove('selected'));
+      card.classList.add('selected');
+      restockPen(sp);
+    };
+
+    const img = document.createElement('img');
+    img.src = `assets/species-icons/${sp}.png`;
+    img.className = 'species-icon';
+
+    const info = document.createElement('div');
+    info.className = 'species-info';
+
+    const name = document.createElement('div');
+    name.className = 'species-name';
+    name.textContent = `${capitalizeFirstLetter(sp)} ($${data.restockCost})`;
+
+    const tagRow = document.createElement('div');
+    tagRow.className = 'species-tags';
+    if (data.tags && data.tags.length) {
+      data.tags.forEach(t => {
+        const span = document.createElement('span');
+        span.className = 'tag';
+        span.textContent = t;
+        tagRow.appendChild(span);
+      });
     }
-    optionsDiv.appendChild(container);
+
+    info.appendChild(name);
+    info.appendChild(tagRow);
+    card.appendChild(img);
+    card.appendChild(info);
+    optionsDiv.appendChild(card);
   });
   document.getElementById('restockModal').classList.add('visible');
 }


### PR DESCRIPTION
## Summary
- replace button list with new species cards in restock modal
- show icons, tags and highlight selection
- style species cards and new secondary button
- update Cancel button markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882cfb8f31483299a96a8f4505df11b