### PR TITLE
Fix species icon sizing in restock modal

### DIFF
--- a/style.css
+++ b/style.css
@@ -1004,6 +1004,7 @@ button:active {
 .species-icon {
   width: 48px;
   height: 48px;
+  object-fit: contain;
 }
 
 .species-info {

--- a/ui.js
+++ b/ui.js
@@ -210,6 +210,7 @@ function renderPenGrid(site){
       const icon = document.createElement('img');
       icon.src = 'assets/species-icons/' + pen.species + '.png';
       icon.alt = pen.species;
+      icon.className = 'species-icon';
       badge.appendChild(icon);
       badge.style.backgroundColor = speciesColors[pen.species] || 'rgba(0,0,0,0.2)';
     } else {
@@ -253,6 +254,7 @@ function updatePenCards(site){
       const icon = document.createElement('img');
       icon.src = 'assets/species-icons/' + pen.species + '.png';
       icon.alt = pen.species;
+      icon.className = 'species-icon';
       badge.appendChild(icon);
       badge.style.backgroundColor = speciesColors[pen.species] || 'rgba(0,0,0,0.2)';
     } else {


### PR DESCRIPTION
## Summary
- ensure species icons use consistent `.species-icon` class
- constrain icon size with new CSS rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882d1d6e4f08329a775c99bb1d37bb5