### PR TITLE
Add farmer icon to staffing stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,8 +71,13 @@
           </div>
           <div id="staffCard" class="staffCard">
             <h2>Staffing</h2>
-            <div>Total: <span id="staffTotal">0</span> / <span id="staffCapacity">0</span></div>
-            <div>Unassigned: <span id="staffUnassigned">0</span></div>
+            <div class="staff-stats">
+              <img src="assets/general-icons/farmer.png" alt="Staff icon" class="staff-icon">
+              <div>
+                <div>Total: <span id="staffTotal">0</span> / <span id="staffCapacity">0</span></div>
+                <div>Unassigned: <span id="staffUnassigned">0</span></div>
+              </div>
+            </div>
             <div class="staff-buttons">
               <button class="staff-button" onclick="hireStaff()">&#x2795; Hire ($500)</button>
               <button class="staff-button" onclick="fireStaff()">&#x1f5d1; Fire</button>

--- a/style.css
+++ b/style.css
@@ -780,6 +780,16 @@ button:active {
   background-color: #555;
   cursor: not-allowed;
 }
+.staff-stats {
+  display: flex;
+  align-items: center;
+  margin: 6px 0;
+}
+.staff-icon {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+}
 .vesselCard div {
   font-size: 14px;
   margin: 6px 0;


### PR DESCRIPTION
## Summary
- add an icon beside staffing statistics in the Staffing card
- style the new icon and wrapper for flexible layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882dd5a70488329b97abe0fe55d6ddc