### PR TITLE
Fix pen card overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -449,10 +449,11 @@ button:active {
 }
 
 #penGridContainer {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   margin-top: 10px;
+  margin-bottom: 20px;
 }
 
 #penGrid {
@@ -462,6 +463,8 @@ button:active {
 .penCard {
   background: var(--bg-panel);
   border-radius: 10px;
+  width: 180px;
+  flex: 0 0 auto;
   padding: 12px;
   text-align: left;
   color: var(--text-light);


### PR DESCRIPTION
## Summary
- make the pen grid container a wrapping flex layout
- give pen cards a fixed width so they don't creep under the Staffing card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882de722d2c83299ce256be430c04a9