### PR TITLE
Increase staffing icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
             <h2>Staffing</h2>
             <div class="staff-stats">
               <img src="assets/general-icons/farmer.png" alt="Staff icon" class="staff-icon">
-              <div>
+              <div class="staff-info">
                 <div>Total: <span id="staffTotal">0</span> / <span id="staffCapacity">0</span></div>
                 <div>Unassigned: <span id="staffUnassigned">0</span></div>
               </div>

--- a/style.css
+++ b/style.css
@@ -789,9 +789,14 @@ button:active {
   margin: 6px 0;
 }
 .staff-icon {
-  width: 24px;
-  height: 24px;
+  flex: 0 0 60%;
+  width: 60%;
+  height: auto;
   margin-right: 8px;
+  object-fit: contain;
+}
+.staff-info {
+  flex: 1;
 }
 .vesselCard div {
   font-size: 14px;


### PR DESCRIPTION
## Summary
- enlarge the staffing icon and adjust layout to give it more weight
- add a wrapper for staff totals in markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e37521b48329835a047caa31cd1f