### PR TITLE
Add site management modal and upgrade actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The most up-to-date build is available on **GitHub Pages**, so you can play onli
 - Each pen has a tiered auto-feeder path from floating rafts to
   underwater systems with individual upgrade costs.
 - Expand your business by buying entirely new sites.
+- Use the **Manage Site** panel to view licenses and purchase site upgrades.
 - Development menu with helper buttons to add cash, harvest all pens and restock them for free.
 - Progress is automatically saved every 30 seconds.
 - Hire and assign staff as feeders, harvesters or feed managers.

--- a/actions.js
+++ b/actions.js
@@ -71,6 +71,38 @@ function buyLicense(sp){
   if(state.cash<cost) return openModal("Not enough cash to buy license.");
   state.cash-=cost; site.licenses.push(sp); updateDisplay();
 }
+
+function purchaseLicense(site, speciesKey){
+  if(!site) site = state.sites[state.currentSiteIndex];
+  const cost = speciesData[speciesKey].licenseCost || 0;
+  if(site.licenses.includes(speciesKey)){
+    return openModal('Already licensed');
+  }
+  if(state.cash < cost){
+    return openModal('Insufficient funds');
+  }
+  state.cash -= cost;
+  site.licenses.push(speciesKey);
+  updateDisplay();
+  if(typeof updateSiteManagementModal === 'function') updateSiteManagementModal();
+  openModal('License purchased successfully');
+}
+
+function purchaseSiteUpgrade(upgradeKey){
+  const site = state.sites[state.currentSiteIndex];
+  const UPGRADE_COST = 25000;
+  if(site.upgrades.includes(upgradeKey)){
+    return openModal('Upgrade already purchased');
+  }
+  if(state.cash < UPGRADE_COST){
+    return openModal('Insufficient funds');
+  }
+  state.cash -= UPGRADE_COST;
+  site.upgrades.push(upgradeKey);
+  updateDisplay();
+  if(typeof updateSiteManagementModal === 'function') updateSiteManagementModal();
+  openModal('Upgrade purchased successfully');
+}
 function buyNewSite(){
   if(state.cash<20000) return openModal("Not enough cash to buy a new site!");
   state.cash-=20000;
@@ -92,7 +124,8 @@ function buyNewSite(){
     })],
     staff: [],
     licenses:['shrimp'],
-    pens:[new Pen({ species:"shrimp", fishCount:500, averageWeight:0.01, bargeIndex:0 })]
+    pens:[new Pen({ species:"shrimp", fishCount:500, averageWeight:0.01, bargeIndex:0 })],
+    upgrades:[]
   }));
   updateDisplay();
   openModal("New site purchased!");
@@ -743,4 +776,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState, openCustomBuild };
+export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState, openCustomBuild };

--- a/gameState.js
+++ b/gameState.js
@@ -131,7 +131,8 @@ state.sites = [
     licenses: ['shrimp'],
     pens: [
       new Pen({ species: 'shrimp', fishCount: 500, averageWeight: 0.01, bargeIndex: 0 })
-    ]
+    ],
+    upgrades: []
   })
 ];
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <button onclick="previousSite()">⟵</button>
         <button onclick="nextSite()">⟶</button>
         <button onclick="buyNewSite()">+ New Site</button>
+        <button id="manageSiteBtn" onclick="openSiteManagementModal()">Manage Site</button>
       </div>
       <div class="top-right">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
@@ -190,6 +191,14 @@
         <h2>Select Destination</h2>
         <div id="moveOptions"></div>
         <button onclick="closeMoveModal()">Cancel</button>
+      </div>
+    </div>
+    <div id="siteManagementModal">
+      <div id="siteManagementModalContent">
+        <h2 id="siteManagementTitle">Site Management</h2>
+        <div id="siteLicenses"></div>
+        <div id="siteUpgrades"></div>
+        <button onclick="closeSiteManagementModal()">Close</button>
       </div>
     </div>
   </div>

--- a/models.js
+++ b/models.js
@@ -47,7 +47,8 @@ export class Site {
     barges = [],
     staff = [],
     licenses = [],
-    pens = []
+    pens = [],
+    upgrades = []
   } = {}) {
     this.name = name;
     this.location = location;
@@ -55,6 +56,7 @@ export class Site {
     this.staff = staff;
     this.licenses = licenses;
     this.pens = pens;
+    this.upgrades = upgrades;
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ import state from './gameState.js';
 import * as ui from './ui.js';
 import * as actions from './actions.js';
 
-Object.assign(window, actions);
+Object.assign(window, actions, ui);
 
 document.addEventListener('DOMContentLoaded', () => {
   actions.loadGame();

--- a/style.css
+++ b/style.css
@@ -180,7 +180,8 @@ button:active {
 #harvestModal,
 #vesselHarvestModal,
 #sellModal,
-#moveModal {
+#moveModal,
+#siteManagementModal {
   position: fixed;
   top: 0;
   left: 0;
@@ -198,7 +199,8 @@ button:active {
 #harvestModal.visible,
 #vesselHarvestModal.visible,
 #sellModal.visible,
-#moveModal.visible {
+#moveModal.visible,
+#siteManagementModal.visible {
   display: flex;
 }
 
@@ -214,6 +216,26 @@ button:active {
   border-radius: 10px;
   text-align: center;
   width: 300px;
+}
+#siteManagementModalContent {
+  background: #293745;
+  color: #dbe5ed;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: left;
+  width: 80%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.license-entry {
+  margin: 4px 0;
+}
+.site-upgrade-card {
+  background: #1f2d35;
+  padding: 10px;
+  border-radius: 8px;
+  margin: 8px 0;
 }
 #sidebarContent,
 #sidebar .panel {

--- a/ui.js
+++ b/ui.js
@@ -395,6 +395,56 @@ function openCustomBuild(){
   openModal('Custom build feature coming soon!');
 }
 
+function updateSiteManagementModal(){
+  const site = state.sites[state.currentSiteIndex];
+  document.getElementById('siteManagementTitle').innerText = `Site Management – ${site.name}`;
+  const licenseDiv = document.getElementById('siteLicenses');
+  licenseDiv.innerHTML = '<h3>Licenses</h3>';
+  site.licenses.forEach(sp=>{
+    licenseDiv.innerHTML += `<div class="license-entry">Species: ${capitalizeFirstLetter(sp)} – ✅</div>`;
+  });
+  const notLicensed = Object.keys(speciesData).filter(sp=>!site.licenses.includes(sp));
+  if(notLicensed.length){
+    const options = notLicensed.map(sp=>`<option value="${sp}">${capitalizeFirstLetter(sp)} - $${speciesData[sp].licenseCost}</option>`).join('');
+    licenseDiv.innerHTML += `<div><select id="licenseBuySelect">${options}</select> <button onclick="buySelectedLicense()">Buy License</button></div>`;
+  } else {
+    licenseDiv.innerHTML += '<div>All licenses acquired</div>';
+  }
+
+  const upDiv = document.getElementById('siteUpgrades');
+  upDiv.innerHTML = '<h3>Site Upgrades</h3>';
+  const upgrades = [
+    {key:'dockUpgrade',name:'Dock Upgrade',desc:'Improves vessel turnaround speed.'},
+    {key:'warehouseExpansion',name:'Warehouse Expansion',desc:'Increases passive storage or barge feed storage.'},
+    {key:'environmentalSensors',name:'Environmental Sensors',desc:'Unlocks weather or seasonal UI in future.'}
+  ];
+  upgrades.forEach(u=>{
+    const owned = site.upgrades && site.upgrades.includes(u.key);
+    const disabled = owned ? 'disabled' : '';
+    const text = owned ? 'Purchased' : 'Upgrade ($25000)';
+    upDiv.innerHTML += `
+      <div class="site-upgrade-card">
+        <h4>${u.name}</h4>
+        <p>${u.desc}</p>
+        <button ${disabled} onclick="purchaseSiteUpgrade('${u.key}')">${text}</button>
+      </div>`;
+  });
+}
+
+function openSiteManagementModal(){
+  updateSiteManagementModal();
+  document.getElementById('siteManagementModal').classList.add('visible');
+}
+
+function closeSiteManagementModal(){
+  document.getElementById('siteManagementModal').classList.remove('visible');
+}
+
+function buySelectedLicense(){
+  const select = document.getElementById('licenseBuySelect');
+  if(select) purchaseLicense(null, select.value);
+}
+
 function sellCargo(idx){
   const vessel = state.vessels[state.currentVesselIndex];
   if(vessel.currentBiomassLoad<=0) return openModal('No biomass to sell.');
@@ -452,5 +502,9 @@ export {
   openSellModal,
   closeSellModal,
   openCustomBuild,
-  sellCargo
+  sellCargo,
+  updateSiteManagementModal,
+  openSiteManagementModal,
+  closeSiteManagementModal,
+  buySelectedLicense
 };


### PR DESCRIPTION
## Summary
- add a Manage Site button to the top bar
- create new **Site Management** modal with licenses and upgrade stubs
- implement `purchaseLicense` and `purchaseSiteUpgrade` actions
- expose UI helpers globally
- style the new modal and upgrade cards
- document Manage Site panel in README

## Testing
- `python3 -m http.server` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_6882edf7d9488329b4c1954468c88ad9