### PR TITLE
Implement site management modal features

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -51,6 +51,7 @@ import {
   setFeedPurchaseMax,
   openSiteManagement as uiOpenSiteManagement,
   closeSiteManagement as uiCloseSiteManagement,
+  updateSiteUpgrades,
   openDevModal as uiOpenDevModal,
   closeDevModal as uiCloseDevModal
 } from "./ui.js";
@@ -77,11 +78,28 @@ function buyFeedStorageUpgrade(){
   state.cash-=up.cost; barge.feedCapacity=up.capacity;
   barge.storageUpgradeLevel++; updateDisplay();
 }
-function buyLicense(sp){
+function purchaseLicense(sp){
   const site = state.sites[state.currentSiteIndex];
-  const cost = speciesData[sp].licenseCost;
-  if(state.cash<cost) return openModal("Not enough cash to buy license.");
-  state.cash-=cost; site.licenses.push(sp); updateDisplay();
+  const cost = speciesData[sp]?.licenseCost || 0;
+  if(site.licenses.includes(sp)) return openModal('Already licensed');
+  if(state.cash < cost) return openModal('Insufficient funds');
+  state.cash -= cost;
+  site.licenses.push(sp);
+  updateDisplay();
+  openModal('License purchased successfully');
+}
+
+function purchaseSiteUpgrade(key){
+  const site = state.sites[state.currentSiteIndex];
+  if(!site.upgrades) site.upgrades = [];
+  if(site.upgrades.includes(key)) return openModal('Upgrade already purchased');
+  const cost = 25000;
+  if(state.cash < cost) return openModal('Insufficient funds');
+  state.cash -= cost;
+  site.upgrades.push(key);
+  updateDisplay();
+  updateSiteUpgrades();
+  openModal('Upgrade purchased successfully');
 }
 function buyNewSite(){
   if(state.cash<20000) return openModal("Not enough cash to buy a new site!");
@@ -1002,4 +1020,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax };
+export { buyFeed, buyFeedStorageUpgrade, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax };

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <button onclick="previousSite()">⟵</button>
         <button onclick="nextSite()">⟶</button>
         <button onclick="buyNewSite()">+ New Site</button>
+        <button id="manageSiteBtn" onclick="openSiteManagement()">Manage Site</button>
       </div>
       <div class="top-right">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
@@ -29,7 +30,6 @@
         </div>
         <button onclick="openMarketReport()">Market Report</button>
         <button onclick="openShipyard()">Shipyard</button>
-        <button onclick="openSiteManagement()">Manage Site</button>
         <button id="devCog" title="Developer Tools">⚙️</button>
       </div>
       </div>
@@ -235,23 +235,24 @@
       <div id="siteManagementContent">
         <button class="close-report-btn" onclick="closeSiteManagement()">Back</button>
         <h2>Site Management – <span id="siteManagementSiteName"></span></h2>
+        <div id="siteLicenses"></div>
         <section id="licenseShop"></section>
-        <h3>Site Infrastructure Upgrades</h3>
-        <div id="upgradeGrid" class="site-upgrade-grid">
-          <div class="upgrade-card">
+        <h3>Site Upgrades</h3>
+        <div id="siteUpgrades" class="site-upgrade-grid">
+          <div class="site-upgrade-card">
             <h4>Dock Upgrade</h4>
-            <p>Increase docking capacity.</p>
-            <button>Upgrade ($X)</button>
+            <p>Improves vessel turnaround speed.</p>
+            <button data-upgrade="dockUpgrade" onclick="purchaseSiteUpgrade('dockUpgrade')">Upgrade ($25000)</button>
           </div>
-          <div class="upgrade-card">
+          <div class="site-upgrade-card">
             <h4>Warehouse Expansion</h4>
-            <p>Expand storage space.</p>
-            <button>Upgrade ($X)</button>
+            <p>Increases passive storage or barge feed storage.</p>
+            <button data-upgrade="warehouseExpansion" onclick="purchaseSiteUpgrade('warehouseExpansion')">Upgrade ($25000)</button>
           </div>
-          <div class="upgrade-card">
+          <div class="site-upgrade-card">
             <h4>Environmental Sensors</h4>
-            <p>Monitor water quality in real time.</p>
-            <button>Upgrade ($X)</button>
+            <p>Unlocks weather or seasonal UI in future.</p>
+            <button data-upgrade="envSensors" onclick="purchaseSiteUpgrade('envSensors')">Upgrade ($25000)</button>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -449,6 +449,20 @@ button:active {
   text-align: left;
 }
 
+#siteLicenses {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.license-entry {
+  background: var(--bg-panel);
+  padding: 6px 8px;
+  border-radius: 6px;
+  margin-bottom: 4px;
+  display: flex;
+  justify-content: space-between;
+}
+
 .site-upgrade-grid {
   display: flex;
   flex-wrap: wrap;
@@ -456,7 +470,7 @@ button:active {
   margin-top: 10px;
 }
 
-.upgrade-card {
+.site-upgrade-card {
   background: var(--bg-panel);
   border-radius: 10px;
   padding: 12px;
@@ -467,11 +481,11 @@ button:active {
   justify-content: space-between;
 }
 
-.upgrade-card h4 {
+.site-upgrade-card h4 {
   margin-top: 0;
 }
 
-.upgrade-card button {
+.site-upgrade-card button {
   margin-top: 8px;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- add Manage Site button to site selector
- build out site management modal with license list and upgrade stubs
- style license entries and upgrade cards
- implement purchaseLicense and purchaseSiteUpgrade logic
- refresh UI lists when licenses or upgrades are bought

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882efb5f14883298f126a8c316cd0c3