### PR TITLE
Disable unfinished site upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,17 +242,17 @@
           <div class="site-upgrade-card">
             <h4>Dock Upgrade</h4>
             <p>Improves vessel turnaround speed.</p>
-            <button data-upgrade="dockUpgrade" onclick="purchaseSiteUpgrade('dockUpgrade')">Upgrade ($25000)</button>
+            <button data-upgrade="dockUpgrade" disabled>Work in Progress</button>
           </div>
           <div class="site-upgrade-card">
             <h4>Warehouse Expansion</h4>
             <p>Increases passive storage or barge feed storage.</p>
-            <button data-upgrade="warehouseExpansion" onclick="purchaseSiteUpgrade('warehouseExpansion')">Upgrade ($25000)</button>
+            <button data-upgrade="warehouseExpansion" disabled>Work in Progress</button>
           </div>
           <div class="site-upgrade-card">
             <h4>Environmental Sensors</h4>
             <p>Unlocks weather or seasonal UI in future.</p>
-            <button data-upgrade="envSensors" onclick="purchaseSiteUpgrade('envSensors')">Upgrade ($25000)</button>
+            <button data-upgrade="envSensors" disabled>Work in Progress</button>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -494,6 +494,11 @@ button:active {
   width: 100%;
 }
 
+.site-upgrade-card button:disabled {
+  background-color: #555;
+  cursor: not-allowed;
+}
+
 #bargeUpgradeMessage {
   margin-bottom: 8px;
   color: #e74c3c;

--- a/ui.js
+++ b/ui.js
@@ -201,11 +201,11 @@ function updateSiteUpgrades(){
   const cards = document.querySelectorAll('#siteUpgrades .site-upgrade-card button');
   cards.forEach(btn => {
     const key = btn.dataset.upgrade;
+    btn.disabled = true;
     if(site.upgrades.includes(key)){
-      btn.disabled = true;
       btn.textContent = 'Purchased';
     } else {
-      btn.disabled = false;
+      btn.textContent = 'Work in Progress';
     }
   });
 }


### PR DESCRIPTION
## Summary
- disable unfinished site upgrade buttons in the Site Management modal
- style disabled site upgrade buttons to appear greyed out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882f94aa390832997346f6aef64941f