### PR TITLE
Implement inline site switcher

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -49,6 +49,9 @@ import {
   syncFeedPurchase,
   confirmBuyFeed,
   setFeedPurchaseMax,
+  toggleSiteList,
+  selectSite,
+  populateSiteList,
   openSiteManagement as uiOpenSiteManagement,
   closeSiteManagement as uiCloseSiteManagement,
   updateSiteUpgrades,
@@ -1020,4 +1023,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyFeedStorageUpgrade, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax };
+export { buyFeed, buyFeedStorageUpgrade, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax, toggleSiteList, selectSite, populateSiteList };

--- a/index.html
+++ b/index.html
@@ -14,9 +14,12 @@
     <div id="topBar">
       <div class="top-bar-group" id="siteGroup">
         <strong>Site:</strong>
-        <span id="siteName">-</span>
-        <button onclick="previousSite()">⟵</button>
-        <button onclick="nextSite()">⟶</button>
+        <div class="site-switcher">
+          <button id="siteNameBtn" onclick="toggleSiteList()">
+            <span id="siteName">-</span> ⌄
+          </button>
+          <div id="siteDropdownList" class="site-list hidden"></div>
+        </div>
         <button onclick="buyNewSite()">+ New Site</button>
         <button id="manageSiteBtn" onclick="openSiteManagement()">Manage Site</button>
       </div>

--- a/style.css
+++ b/style.css
@@ -65,6 +65,10 @@ button:active {
   transform: scale(0.97);
 }
 
+.hidden {
+  display: none !important;
+}
+
 /* Tab Bar */
 #tabBar {
   margin-top: 10px;
@@ -921,6 +925,49 @@ button:active {
 .top-bar-group button:hover {
   background-color: var(--accent);
   color: var(--bg-darker);
+}
+
+.site-switcher {
+  position: relative;
+  display: inline-block;
+}
+
+.site-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--bg-panel);
+  border-radius: 6px;
+  box-shadow: 0 2px 6px var(--shadow-light);
+  padding: 4px 0;
+  opacity: 0;
+  transform: scale(0.95);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 200;
+  min-width: 120px;
+  text-align: left;
+}
+
+.site-list.visible {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.site-list div {
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.site-list div:hover {
+  background-color: var(--accent);
+  color: var(--bg-darker);
+}
+
+.site-list .active {
+  background-color: var(--accent-translucent);
+  font-weight: bold;
 }
 
 /* Mobile sidebar behavior */

--- a/ui.js
+++ b/ui.js
@@ -39,6 +39,18 @@ const vesselIcons = {
   wellboat: '🚤'
 };
 
+// close site dropdown when clicking outside
+document.addEventListener('click', evt => {
+  const list = document.getElementById('siteDropdownList');
+  const btn  = document.getElementById('siteNameBtn');
+  if(!list || !btn) return;
+  if(list.classList.contains('visible') &&
+     !list.contains(evt.target) && !btn.contains(evt.target)){
+    list.classList.remove('visible');
+    list.classList.add('hidden');
+  }
+});
+
 // Track counts to avoid re-rendering lists every tick
 let lastSiteIndex = -1;
 let lastPenCount = 0;
@@ -51,6 +63,7 @@ function updateDisplay(){
 
   // top-bar
   document.getElementById('siteName').innerText = site.name;
+  populateSiteList();
   document.getElementById('cashCount').innerText = state.cash.toFixed(2);
   const dateEl = document.getElementById('dateDisplay');
   if(dateEl) dateEl.innerText = getDateString();
@@ -1124,6 +1137,45 @@ function setFeedPurchaseMax(){
   updateFeedPurchaseCost();
 }
 
+// --- Site Switcher ---
+function toggleSiteList(){
+  const list = document.getElementById('siteDropdownList');
+  if(!list) return;
+  if(list.classList.contains('visible')){
+    list.classList.remove('visible');
+    list.classList.add('hidden');
+  } else {
+    list.classList.remove('hidden');
+    list.classList.add('visible');
+  }
+}
+
+function selectSite(index){
+  if(index < 0 || index >= state.sites.length) return;
+  state.currentSiteIndex = index;
+  state.currentPenIndex = 0;
+  state.currentBargeIndex = 0;
+  updateDisplay();
+  const list = document.getElementById('siteDropdownList');
+  if(list){
+    list.classList.remove('visible');
+    list.classList.add('hidden');
+  }
+}
+
+function populateSiteList(){
+  const list = document.getElementById('siteDropdownList');
+  if(!list) return;
+  list.innerHTML = '';
+  state.sites.forEach((s, i) => {
+    const item = document.createElement('div');
+    item.textContent = s.name;
+    if(i === state.currentSiteIndex) item.classList.add('active');
+    item.onclick = () => selectSite(i);
+    list.appendChild(item);
+  });
+}
+
 // --- PURCHASES & ACTIONS ---
 export {
   updateDisplay,
@@ -1161,5 +1213,8 @@ export {
   updateFeedPurchaseUI,
   syncFeedPurchase,
   confirmBuyFeed,
-  setFeedPurchaseMax
+  setFeedPurchaseMax,
+  toggleSiteList,
+  selectSite,
+  populateSiteList
 };


### PR DESCRIPTION
## Summary
- replace previous/next site buttons with inline drop-down site switcher
- style new site dropdown and add generic `.hidden` helper
- populate and control site dropdown via `toggleSiteList`, `selectSite`, `populateSiteList`
- expose new UI functions through `actions.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688305ec29188329b1a8e14f35df5347