### PR TITLE
Add responsive mobile layout for top bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The most up-to-date build is available on **GitHub Pages**, so you can play onli
 - Upgrade staff housing and barge tiers to unlock more automation.
 - Operate harvest vessels, move them between sites and markets and sell cargo.
 - Interactive map displays sites, markets and vessel locations.
+- Mobile-friendly top bar collapses into a vertical layout on small screens.
 - Game state is saved in local storage so progress persists across sessions.
 - In-game time tracks days, seasons and years that advance automatically.
 

--- a/index.html
+++ b/index.html
@@ -10,14 +10,14 @@
   <div class="container">
     <!-- Top bar: site nav on left, cash on right -->
     <div id="topBar">
-      <div class="top-left">
+      <div class="top-bar-group site-switcher">
         <strong>Site:</strong>
         <span id="siteName">-</span>
         <button onclick="previousSite()">⟵</button>
         <button onclick="nextSite()">⟶</button>
         <button onclick="buyNewSite()">+ New Site</button>
       </div>
-      <div class="top-right">
+      <div class="top-bar-group">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
         <div><strong>Date:</strong> <span id="dateDisplay">Spring 1, Year 1</span></div>
       </div>

--- a/style.css
+++ b/style.css
@@ -408,13 +408,13 @@ button:active {
   max-width: 900px;
 }
 
-.top-left, .top-right {
+.top-bar-group {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.top-left button, .top-right button {
+.top-bar-group button {
   font-size: 14px;
   padding: 6px 12px;
   background-color: #2b3b4a;
@@ -424,7 +424,7 @@ button:active {
   cursor: pointer;
 }
 
-.top-left button:hover, .top-right button:hover {
+.top-bar-group button:hover {
   background-color: #4be0ff;
   color: #142027;
 }
@@ -467,4 +467,26 @@ button:active {
 #shop button {
   width: 100%;
   margin: 4px 0;
+}
+
+@media (max-width: 600px) {
+  #topBar {
+    flex-direction: column;
+    gap: 10px;
+    align-items: stretch;
+  }
+
+  .top-bar-group {
+    width: 100%;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .top-bar-group button {
+    flex: 1 1 48%;
+  }
+
+  .site-switcher {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- style top bar groups with unified `.top-bar-group` class
- collapse top bar vertically at widths under 600px
- update HTML to use new classes
- document mobile-friendly top bar in README

## Testing
- `python3 -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_6883080f2ae4832984dccd6c82555dac