### PR TITLE
Add mobile action toggle

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -50,6 +50,7 @@ import {
   confirmBuyFeed,
   setFeedPurchaseMax,
   toggleSiteList,
+  toggleMobileActions,
   selectSite,
   populateSiteList,
   openSiteManagement as uiOpenSiteManagement,
@@ -355,6 +356,11 @@ function closeSiteManagement(){
 }
 function openDevModal(){ uiOpenDevModal(); }
 function closeDevModal(){ uiCloseDevModal(); }
+function toggleDevTools(){
+  const modal = document.getElementById('devModal');
+  if(modal.classList.contains('visible')) uiCloseDevModal();
+  else uiOpenDevModal();
+}
 function openCustomBuild(){
   uiOpenCustomBuild();
 }
@@ -1023,4 +1029,4 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyFeedStorageUpgrade, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax, toggleSiteList, selectSite, populateSiteList };
+export { buyFeed, buyFeedStorageUpgrade, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, toggleDevTools, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax, toggleSiteList, toggleMobileActions, selectSite, populateSiteList };

--- a/index.html
+++ b/index.html
@@ -33,9 +33,16 @@
         </div>
       </div>
       <div class="top-bar-group" id="toolsGroup">
-        <button onclick="openMarketReport()">Market Report</button>
-        <button onclick="openShipyard()">Shipyard</button>
-        <button id="devCog" title="Developer Tools">⚙️</button>
+        <div class="mobile-action-wrapper">
+          <button id="mobileActionToggle" onclick="toggleMobileActions()">
+            <img src="assets/general-icons/browser.png" alt="Tools" class="icon-img" />
+          </button>
+          <div id="mobileActionGroup" class="hidden">
+            <button onclick="openMarketReport()">Market</button>
+            <button onclick="openShipyard()">Shipyard</button>
+            <button onclick="toggleDevTools()">⚙️</button>
+          </div>
+        </div>
       </div>
     </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -19,14 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
   actions.loadGame();
   ui.updateDisplay();
   ui.setupMapInteractions();
-  const cog = document.getElementById('devCog');
-  if(cog){
-    cog.addEventListener('click', () => {
-      const modal = document.getElementById('devModal');
-      if(modal.classList.contains('visible')) ui.closeDevModal();
-      else ui.openDevModal();
-    });
-  }
   if(state.lastOfflineInfo){
     const days = state.lastOfflineInfo.daysPassed;
     const feed = state.lastOfflineInfo.feedUsed.toFixed(0);

--- a/style.css
+++ b/style.css
@@ -970,6 +970,64 @@ button:active {
   font-weight: bold;
 }
 
+.mobile-action-wrapper {
+  position: relative;
+}
+
+#mobileActionToggle {
+  background-color: var(--bg-button);
+  border: none;
+  border-radius: 6px;
+  padding: 6px;
+}
+
+.icon-img {
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+}
+
+#mobileActionGroup {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--bg-panel);
+  box-shadow: 0 2px 6px var(--shadow-light);
+  border-radius: 6px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 200;
+}
+
+#mobileActionGroup.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+@media (min-width: 601px) {
+  #mobileActionToggle {
+    display: none;
+  }
+  #mobileActionGroup {
+    position: static;
+    flex-direction: row;
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+    display: flex;
+  }
+  #mobileActionGroup.hidden {
+    display: flex !important;
+  }
+}
+
 /* Mobile sidebar behavior */
 @media (max-width: 700px) {
   #sidebar {

--- a/ui.js
+++ b/ui.js
@@ -51,6 +51,31 @@ document.addEventListener('click', evt => {
   }
 });
 
+function toggleMobileActions(){
+  const group = document.getElementById('mobileActionGroup');
+  if(!group) return;
+  if(group.classList.contains('visible')){
+    group.classList.remove('visible');
+    group.classList.add('hidden');
+  } else {
+    group.classList.remove('hidden');
+    group.classList.add('visible');
+  }
+}
+
+function outsideMobileActionHandler(evt){
+  const group = document.getElementById('mobileActionGroup');
+  const toggle = document.getElementById('mobileActionToggle');
+  if(!group || !toggle) return;
+  if(group.classList.contains('visible') &&
+     !group.contains(evt.target) && !toggle.contains(evt.target)){
+    group.classList.remove('visible');
+    group.classList.add('hidden');
+  }
+}
+
+document.addEventListener('click', outsideMobileActionHandler);
+
 // Track counts to avoid re-rendering lists every tick
 let lastSiteIndex = -1;
 let lastPenCount = 0;
@@ -1215,6 +1240,8 @@ export {
   confirmBuyFeed,
   setFeedPurchaseMax,
   toggleSiteList,
+  toggleMobileActions,
+  outsideMobileActionHandler,
   selectSite,
   populateSiteList
 };


### PR DESCRIPTION
## Summary
- replace Market, Shipyard and Dev buttons with a new mobile action menu
- style the new action menu and icon
- manage menu open/close via `toggleMobileActions` and `outsideMobileActionHandler`
- provide `toggleDevTools` helper
- remove old developer tools toggle wiring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883091de1c88329a58a26b425b92919