### PR TITLE
Add time control button and icon polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The most up-to-date build is available on **GitHub Pages**, so you can play onli
 - Mobile-friendly top bar collapses into a vertical layout on small screens.
 - Game state is saved in local storage so progress persists across sessions.
 - In-game time tracks days, seasons and years that advance automatically.
+- Pause or resume time with the play/pause button in the top bar.
 
 ### Time Data
 Several read-only time values are exposed on the global `window` object:

--- a/actions.js
+++ b/actions.js
@@ -741,6 +741,12 @@ function nextBarge(){ const site = state.sites[state.currentSiteIndex]; if(state
 function previousVessel(){ if(state.currentVesselIndex>0) state.currentVesselIndex--; updateDisplay(); }
 function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state.currentVesselIndex++; updateDisplay(); }
 
+function toggleTime(){
+  state.timePaused = !state.timePaused;
+  addStatusMessage(state.timePaused ? 'Paused' : 'Resumed');
+  updateDisplay();
+}
 
 
-export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState, openCustomBuild };
+
+export { buyFeed, buyMaxFeed, buyFeedStorageUpgrade, buyLicense, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeStaffHousing, upgradeBarge, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, openHarvestModal, closeHarvestModal, confirmHarvest, openVesselHarvestModal, closeVesselHarvestModal, confirmVesselHarvest, feedFishPen, harvestPenIndex, harvestWithVessel, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, toggleSection, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, toggleTime, upgradeVessel, buyNewVessel, renameVessel, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, getTimeState, openCustomBuild };

--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
       <div class="top-bar-group">
         <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
         <div><strong>Date:</strong> <span id="dateDisplay">Spring 1, Year 1</span></div>
+        <button id="timeToggle" onclick="toggleTime()">
+          <img id="timeToggleIcon" class="icon-img" alt="Toggle Time">
+        </button>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -1,4 +1,29 @@
 /* Global Styles */
+:root {
+  --bg-light: #1f2d35;
+}
+
+.icon-img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  filter: brightness(0) invert(1);
+}
+
+.site-list .active {
+  background-color: var(--bg-light);
+  font-weight: bold;
+}
+
+#timeToggle.paused .icon-img {
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}
 body {
   font-family: Arial, sans-serif;
   background: #1a272e;
@@ -90,6 +115,11 @@ button:active {
 }
 #toggleSidebar:hover {
   background-color: #1f2d35;
+}
+
+#mobileActionToggle:hover .icon-img {
+  transform: scale(1.1);
+  transition: transform 0.15s ease;
 }
 #sidebarContent {
   overflow-y: auto;

--- a/ui.js
+++ b/ui.js
@@ -17,6 +17,9 @@ import state, {
   getSiteHarvestRate,
 } from "./gameState.js";
 
+const PLAY_ICON = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBvbHlnb24gcG9pbnRzPSI4LDUgMTksMTIgOCwxOSIvPjwvc3ZnPg==';
+const PAUSE_ICON = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3QgeD0iNiIgeT0iNSIgd2lkdGg9IjQiIGhlaWdodD0iMTQiLz48cmVjdCB4PSIxNCIgeT0iNSIgd2lkdGg9IjQiIGhlaWdodD0iMTQiLz48L3N2Zz4=';
+
 // --- UPDATE UI ---
 function updateDisplay(){
   const site = state.sites[state.currentSiteIndex];
@@ -105,6 +108,17 @@ function updateDisplay(){
   renderMap();
   const statusEl = document.getElementById('statusMessages');
   if(statusEl) statusEl.innerText = state.statusMessage;
+  const timeToggle = document.getElementById('timeToggle');
+  const icon = document.getElementById('timeToggleIcon');
+  if(timeToggle && icon){
+    if(state.timePaused){
+      timeToggle.classList.add('paused');
+      icon.src = PLAY_ICON;
+    } else {
+      timeToggle.classList.remove('paused');
+      icon.src = PAUSE_ICON;
+    }
+  }
 }
 
 // harvest preview


### PR DESCRIPTION
## Summary
- add a play/pause button to control time progression
- expose base64 icons and update display logic to swap icons
- add CSS variables and standardized icon rules
- highlight active site list items and hover states
- document pause/resume feature

## Testing
- `python3 -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_68830b794c88832995021ad82acc605a