### PR TITLE
Refactor site actions dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,15 +20,14 @@
           </button>
           <div id="siteDropdownList" class="site-list hidden"></div>
         </div>
-        <div class="icon-action-bar">
-          <img src="assets/general-icons/cagesystem.png"
-               alt="Site Actions"
-               class="icon-button"
-               onclick="toggleSiteActions()" />
-        </div>
-        <div id="siteActionMenu" class="icon-menu hidden">
-          <div onclick="buyNewSite()">+ New Site</div>
-          <div onclick="openSiteManagement()">Manage Site</div>
+        <div class="mobile-action-wrapper" id="siteActionGroup">
+          <button id="siteActionToggle" onclick="toggleSiteActions()">
+            <img src="assets/general-icons/cagesystem.png" alt="Site Actions" class="icon-img" />
+          </button>
+          <div id="siteActionMenu" class="hidden">
+            <button onclick="buyNewSite()">+ New Site</button>
+            <button onclick="openSiteManagement()">Manage Site</button>
+          </div>
         </div>
       </div>
       <div class="top-bar-group" id="statusGroup">

--- a/style.css
+++ b/style.css
@@ -982,6 +982,13 @@ button:active {
   padding: 6px;
 }
 
+#siteActionToggle {
+  background-color: var(--bg-button);
+  border: none;
+  border-radius: 6px;
+  padding: 6px;
+}
+
 .icon-img {
   width: 24px;
   height: 24px;
@@ -1006,7 +1013,31 @@ button:active {
   z-index: 200;
 }
 
+#siteActionMenu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--bg-panel);
+  box-shadow: 0 2px 6px var(--shadow-light);
+  border-radius: 6px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 200;
+}
+
 #mobileActionGroup.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+#siteActionMenu.visible {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
@@ -1079,6 +1110,20 @@ button:active {
     display: flex;
   }
   #mobileActionGroup.hidden {
+    display: flex !important;
+  }
+  #siteActionToggle {
+    display: none;
+  }
+  #siteActionMenu {
+    position: static;
+    flex-direction: row;
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+    display: flex;
+  }
+  #siteActionMenu.hidden {
     display: flex !important;
   }
 }

--- a/ui.js
+++ b/ui.js
@@ -91,7 +91,7 @@ function toggleSiteActions(){
 
 function outsideSiteActionHandler(e){
   const menu = document.getElementById('siteActionMenu');
-  const toggle = document.querySelector('img[onclick="toggleSiteActions()"]');
+  const toggle = document.getElementById('siteActionToggle');
   if(!menu || !toggle) return;
   if(!menu.contains(e.target) && !toggle.contains(e.target)){
     menu.classList.remove('visible');


### PR DESCRIPTION
## Summary
- restructure Site Actions icon to mirror Tools group layout
- add matching CSS and responsive rules for Site Actions
- update JS to handle new IDs for the dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883159a7f2c8329a763a018cb32d86c