### PR TITLE
Improve top bar icon buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,7 @@
           <div id="siteDropdownList" class="site-list hidden"></div>
         </div>
         <div class="mobile-action-wrapper" id="siteActionGroup">
-          <button id="siteActionToggle" onclick="toggleSiteActions()">
-            <img src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-img" />
-          </button>
+          <img id="siteActionToggle" src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-button" onclick="toggleSiteActions()" />
           <div id="siteActionMenu" class="hidden">
             <button onclick="buyNewSite()">+ New Site</button>
             <button onclick="openSiteManagement()">Manage Site</button>
@@ -41,9 +39,7 @@
       </div>
       <div class="top-bar-group" id="toolsGroup">
         <div class="mobile-action-wrapper">
-          <button id="mobileActionToggle" onclick="toggleMobileActions()">
-            <img src="assets/general-icons/browser.png" alt="Tools" class="icon-img" />
-          </button>
+          <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" onclick="toggleMobileActions()" />
           <div id="mobileActionGroup" class="hidden">
             <button onclick="openMarketReport()">Market</button>
             <button onclick="openShipyard()">Shipyard</button>

--- a/style.css
+++ b/style.css
@@ -975,18 +975,12 @@ button:active {
   position: relative;
 }
 
-#mobileActionToggle {
-  background-color: var(--bg-button);
-  border: none;
-  border-radius: 6px;
-  padding: 6px;
-}
-
+#mobileActionToggle,
 #siteActionToggle {
-  background-color: var(--bg-button);
+  /* Images act as buttons, no extra styling */
+  padding: 0;
+  background: none;
   border: none;
-  border-radius: 6px;
-  padding: 6px;
 }
 
 .icon-img {
@@ -1051,8 +1045,9 @@ button:active {
 }
 
 .icon-button {
-  width: 36px;
-  height: 36px;
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
   cursor: pointer;
   filter: brightness(0) invert(1);
   transition: filter 0.2s ease, transform 0.2s ease;
@@ -1060,8 +1055,8 @@ button:active {
 
 .icon-button:hover,
 .icon-button:active {
-  filter: drop-shadow(0 0 4px var(--accent)) brightness(1.3) invert(0.9);
-  transform: scale(1.1);
+  filter: drop-shadow(0 0 6px var(--accent)) brightness(1.3) invert(0.9);
+  transform: scale(1.05);
 }
 
 .icon-menu {


### PR DESCRIPTION
## Summary
- make `siteactions.png` and `browser.png` act directly as buttons
- enlarge icons via `.icon-button` styling
- remove padding/background from the icon toggle elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883193d8f9083299f16c65a2dff1b8b