### PR TITLE
Add inline icons in top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <!-- Top bar grouped for easier styling -->
     <div id="topBar">
       <div class="top-bar-group" id="siteGroup">
+        <img src="assets/general-icons/siteactions.png" alt="Site" class="icon-inline" />
         <strong>Site:</strong>
         <div class="site-switcher">
           <button id="siteNameBtn" onclick="toggleSiteList()">
@@ -38,6 +39,7 @@
         </div>
       </div>
       <div class="top-bar-group" id="toolsGroup">
+        <img src="assets/general-icons/browser.png" alt="Tools" class="icon-inline" />
         <div class="mobile-action-wrapper">
           <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" onclick="toggleMobileActions()" />
           <div id="mobileActionGroup" class="hidden">

--- a/style.css
+++ b/style.css
@@ -1058,6 +1058,19 @@ button:active {
   filter: drop-shadow(0 0 6px var(--accent)) brightness(1.3) invert(0.9);
   transform: scale(1.05);
 }
+.icon-inline {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  filter: brightness(0) invert(1);
+  margin-right: 12px;
+}
+
+@media (max-width: 600px) {
+  .icon-inline {
+    display: none;
+  }
+}
 
 .icon-menu {
   position: absolute;


### PR DESCRIPTION
## Summary
- show inline icons for the Site and Tools groups on desktop
- style icons with `.icon-inline` and hide them on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831ae2b54483298d4a978e9c584bf5