### PR TITLE
Improve mobile top bar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       </div>
       <div class="top-bar-group" id="toolsGroup">
         <img src="assets/general-icons/browser.png" alt="Tools" class="icon-inline" />
-        <div class="mobile-action-wrapper">
+        <div class="mobile-action-wrapper" id="toolsActionGroup">
           <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" onclick="toggleMobileActions()" />
           <div id="mobileActionGroup" class="hidden">
             <button onclick="openMarketReport()">Market</button>
@@ -49,6 +49,7 @@
           </div>
         </div>
       </div>
+      <div id="mobileIconBar" class="icon-action-bar"></div>
     </div>
     </div>
   </header>

--- a/script.js
+++ b/script.js
@@ -14,8 +14,28 @@ function adjustHeaderPadding(){
 
 window.addEventListener('resize', adjustHeaderPadding);
 
+function reflowTopBar(){
+  const mobileBreak = 500;
+  const siteGroup = document.getElementById('siteGroup');
+  const siteActions = document.getElementById('siteActionGroup');
+  const toolsGroup = document.getElementById('toolsGroup');
+  const toolsActions = document.getElementById('toolsActionGroup');
+  const mobileBar = document.getElementById('mobileIconBar');
+  if(!siteGroup || !siteActions || !toolsGroup || !toolsActions || !mobileBar) return;
+  if(window.innerWidth <= mobileBreak){
+    if(!mobileBar.contains(siteActions)) mobileBar.appendChild(siteActions);
+    if(!mobileBar.contains(toolsActions)) mobileBar.appendChild(toolsActions);
+  } else {
+    if(!siteGroup.contains(siteActions)) siteGroup.appendChild(siteActions);
+    if(!toolsGroup.contains(toolsActions)) toolsGroup.appendChild(toolsActions);
+  }
+}
+
+window.addEventListener('resize', reflowTopBar);
+
 document.addEventListener('DOMContentLoaded', () => {
   adjustHeaderPadding();
+  reflowTopBar();
   actions.loadGame();
   ui.updateDisplay();
   ui.setupMapInteractions();

--- a/style.css
+++ b/style.css
@@ -1044,6 +1044,16 @@ button:active {
   margin-top: 6px;
 }
 
+#mobileIconBar {
+  display: none;
+}
+
+@media (max-width: 500px) {
+  #mobileIconBar {
+    display: flex;
+  }
+}
+
 .icon-button {
   width: 72px;
   height: 72px;


### PR DESCRIPTION
## Summary
- add mobile icon bar container for action icons
- add responsive CSS to show mobile icon bar only on small screens
- move site and tool action wrappers on resize for mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831c22f4608329b3d1c2d53e2fcee3