### PR TITLE
Fix mobile top bar spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -898,6 +898,10 @@ button:active {
   #topBar {
     flex-direction: column;
     gap: 6px;
+    padding: 8px 12px;
+  }
+  .top-bar-group {
+    gap: 6px;
   }
 }
 
@@ -1051,6 +1055,13 @@ button:active {
 @media (max-width: 500px) {
   #mobileIconBar {
     display: flex;
+  }
+  .icon-action-bar {
+    gap: 8px;
+  }
+  .icon-button {
+    width: 48px;
+    height: 48px;
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten top bar spacing on small screens
- shrink icon bar gap and icon button dimensions on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831e6d5060832984c2938d0ef05bb6