### PR TITLE
Add developer utilities modal overhaul

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -659,6 +659,75 @@ function devAddBiomass(amount = 10){
   updateDisplay();
 }
 
+function devRestartGame() {
+  if (confirm("Restart the game?")) {
+    localStorage.clear();
+    location.reload();
+  }
+}
+
+function devAdvanceTime(days) {
+  for (let i = 0; i < days; i++) state.advanceDay();
+  updateDisplay();
+}
+
+function devSetDatePrompt() {
+  const season = prompt("Season (Spring, Summer, Fall, Winter):");
+  const year = parseInt(prompt("Year:"), 10);
+  if (season && !isNaN(year)) {
+    state.season = season;
+    state.year = year;
+    updateDisplay();
+  }
+}
+
+function devSetTimeScalePrompt() {
+  const scale = parseFloat(prompt("Set game speed multiplier:"));
+  if (!isNaN(scale) && scale > 0) state.timeScale = scale;
+}
+
+function devResetMarketPrices() {
+  state.markets.forEach(market => {
+    Object.keys(market.basePrices).forEach(species => {
+      market.prices[species] = market.basePrices[species];
+    });
+  });
+  updateDisplay();
+}
+
+function devRandomizeMarket() {
+  updateMarketPrices();
+}
+
+function devSetMarketModifierPrompt() {
+  const market = prompt("Market name:");
+  const species = prompt("Species name:");
+  const modifier = parseFloat(prompt("Modifier (e.g. 1.2):"));
+  const target = state.markets.find(m => m.name === market);
+  if (target && !isNaN(modifier)) {
+    target.priceModifiers[species] = modifier;
+  }
+  updateDisplay();
+}
+
+function calculateHarvestIncome(pen) {
+  const species = pen.species;
+  const biomass = pen.fishCount * pen.averageWeight;
+  const price = state.markets[0].prices?.[species] ?? speciesData[species].marketPrice;
+  return biomass * price;
+}
+
+function devInstantSellAll() {
+  state.sites.forEach(site => {
+    site.pens.forEach(pen => {
+      state.cash += calculateHarvestIncome(pen);
+      pen.fishCount = 0;
+      pen.averageWeight = 0;
+    });
+  });
+  updateDisplay();
+}
+
 // sidebar nav
 function togglePanel(id){
   const p = document.getElementById(id);
@@ -1030,4 +1099,98 @@ function nextVessel(){ if(state.currentVesselIndex<state.vessels.length-1) state
 
 
 
-export { buyFeed, buyFeedStorageUpgrade, purchaseLicense, purchaseSiteUpgrade, buyNewSite, buyNewPen, buyNewBarge, hireStaff, fireStaff, assignStaff, unassignStaff, upgradeSilo, upgradeBlower, upgradeHousing, upgradeStaffHousing, addDevCash, devHarvestAll, devRestockAll, devAddBiomass, togglePanel, openModal, closeModal, openRestockModal, closeRestockModal, closeHarvestModal, confirmHarvest, harvestPen, cancelVesselHarvest, feedFishPen, restockPen, restockPenUI, upgradeFeeder, assignBarge, openSellModal, closeSellModal, sellCargo, startOffloading, finishOffloading, saveGame, loadGame, resetGame, previousSite, nextSite, previousBarge, nextBarge, previousVessel, nextVessel, upgradeVessel, buyNewVessel, renameVessel, closeRenameModal, confirmRename, openMoveVesselModal, closeMoveModal, moveVesselTo, showTab, updateSelectedBargeDisplay, openBargeUpgradeModal, closeBargeUpgradeModal, openShipyard, closeShipyard, openCustomBuild, backToShipyardList, updateCustomBuildStats, buyShipyardVessel, confirmCustomBuild, openMarketReport, closeMarketReport, openSiteManagement, closeSiteManagement, openDevModal, closeDevModal, toggleDevTools, getTimeState, pauseTime, resumeTime, updateFeedPurchaseUI, syncFeedPurchase, confirmBuyFeed, setFeedPurchaseMax, toggleSiteList, toggleMobileActions, toggleSiteActions, selectSite, populateSiteList };
+export {
+  buyFeed,
+  buyFeedStorageUpgrade,
+  purchaseLicense,
+  purchaseSiteUpgrade,
+  buyNewSite,
+  buyNewPen,
+  buyNewBarge,
+  hireStaff,
+  fireStaff,
+  assignStaff,
+  unassignStaff,
+  upgradeSilo,
+  upgradeBlower,
+  upgradeHousing,
+  upgradeStaffHousing,
+  addDevCash,
+  devHarvestAll,
+  devRestockAll,
+  devAddBiomass,
+  devRestartGame,
+  devAdvanceTime,
+  devSetDatePrompt,
+  devSetTimeScalePrompt,
+  devResetMarketPrices,
+  devRandomizeMarket,
+  devSetMarketModifierPrompt,
+  devInstantSellAll,
+  togglePanel,
+  openModal,
+  closeModal,
+  openRestockModal,
+  closeRestockModal,
+  closeHarvestModal,
+  confirmHarvest,
+  harvestPen,
+  cancelVesselHarvest,
+  feedFishPen,
+  restockPen,
+  restockPenUI,
+  upgradeFeeder,
+  assignBarge,
+  openSellModal,
+  closeSellModal,
+  sellCargo,
+  startOffloading,
+  finishOffloading,
+  saveGame,
+  loadGame,
+  resetGame,
+  previousSite,
+  nextSite,
+  previousBarge,
+  nextBarge,
+  previousVessel,
+  nextVessel,
+  upgradeVessel,
+  buyNewVessel,
+  renameVessel,
+  closeRenameModal,
+  confirmRename,
+  openMoveVesselModal,
+  closeMoveModal,
+  moveVesselTo,
+  showTab,
+  updateSelectedBargeDisplay,
+  openBargeUpgradeModal,
+  closeBargeUpgradeModal,
+  openShipyard,
+  closeShipyard,
+  openCustomBuild,
+  backToShipyardList,
+  updateCustomBuildStats,
+  buyShipyardVessel,
+  confirmCustomBuild,
+  openMarketReport,
+  closeMarketReport,
+  openSiteManagement,
+  closeSiteManagement,
+  openDevModal,
+  closeDevModal,
+  toggleDevTools,
+  getTimeState,
+  pauseTime,
+  resumeTime,
+  updateFeedPurchaseUI,
+  syncFeedPurchase,
+  confirmBuyFeed,
+  setFeedPurchaseMax,
+  toggleSiteList,
+  toggleMobileActions,
+  toggleSiteActions,
+  selectSite,
+  populateSiteList
+};

--- a/index.html
+++ b/index.html
@@ -241,11 +241,39 @@
     <div id="devModal">
       <div id="devModalContent">
         <h2>Developer Tools</h2>
+        <h3>Cash &amp; Fish</h3>
         <button onclick="addDevCash()">Add $100k</button>
         <button onclick="devHarvestAll()">Harvest All Pens</button>
         <button onclick="devRestockAll()">Restock All (Free)</button>
         <button onclick="devAddBiomass()">+10kg Biomass (Pen)</button>
+
+        <h3>Time Control</h3>
+        <button onclick="devAdvanceTime(1)">+1 Day</button>
+        <button onclick="devAdvanceTime(7)">+1 Week</button>
+        <button onclick="devSetDatePrompt()">Set Date</button>
+        <button onclick="devSetTimeScalePrompt()">Adjust Time Scale</button>
+
+        <h3>Market Tools</h3>
+        <button onclick="devResetMarketPrices()">Reset Market Prices</button>
+        <button onclick="devRandomizeMarket()">Randomize Market</button>
+        <button onclick="devSetMarketModifierPrompt()">Set Market Modifier</button>
+        <button onclick="devInstantSellAll()">Instant Sell All Biomass</button>
+
+        <h3>Utilities</h3>
+        <button onclick="devRestartGame()">Restart Game</button>
+        <button onclick="openSpeciesData()">Species Data</button>
         <button onclick="closeDevModal()">Close</button>
+      </div>
+    </div>
+
+    <div id="speciesDataModal">
+      <div id="speciesDataContent">
+        <h2>Species Data</h2>
+        <table id="speciesTable">
+          <thead><tr><th>Name</th><th>FCR</th><th>Restock</th><th>Growth</th></tr></thead>
+          <tbody></tbody>
+        </table>
+        <button onclick="closeSpeciesData()">Close</button>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -450,6 +450,47 @@ button:active {
   width: 340px;
 }
 
+#devModalContent h3 {
+  margin-top: 16px;
+  font-size: 14px;
+  color: var(--text-light);
+}
+
+#speciesDataModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#speciesDataModal.visible {
+  display: flex;
+}
+
+#speciesDataContent {
+  background: var(--modal-bg);
+  color: var(--text-light);
+  padding: 16px;
+  border-radius: 8px;
+  width: 340px;
+  text-align: center;
+}
+
+#speciesTable {
+  width: 100%;
+  font-size: 13px;
+  margin: 10px 0;
+}
+#speciesTable th, #speciesTable td {
+  padding: 4px;
+}
+
 #siteManagementContent {
   width: 90%;
   max-width: 800px;

--- a/ui.js
+++ b/ui.js
@@ -1088,6 +1088,27 @@ function closeDevModal(){
   document.getElementById('devModal').classList.remove('visible');
 }
 
+function openSpeciesData() {
+  const modal = document.getElementById('speciesDataModal');
+  const tbody = modal.querySelector('tbody');
+  tbody.innerHTML = '';
+  Object.entries(speciesData).forEach(([name, s]) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${name}</td>
+      <td>${s.fcr ?? '-'}</td>
+      <td>${s.restockCount ?? '-'}</td>
+      <td>${s.growthRate ?? '-'}</td>
+    `;
+    tbody.appendChild(row);
+  });
+  modal.classList.add('visible');
+}
+
+function closeSpeciesData() {
+  document.getElementById('speciesDataModal').classList.remove('visible');
+}
+
 function updateMarketCharts(){
   const charts = document.querySelectorAll('.market-chart');
   charts.forEach(c => {
@@ -1259,6 +1280,8 @@ export {
   updateSiteUpgrades,
   openDevModal,
   closeDevModal,
+  openSpeciesData,
+  closeSpeciesData,
   updateFeedPurchaseUI,
   syncFeedPurchase,
   confirmBuyFeed,


### PR DESCRIPTION
## Summary
- organize developer modal into grouped sections
- add species data modal
- style new modal headers and species data layout
- implement new developer actions for time, market, and utilities
- expose species data functions in UI module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831f3bb4fc8329b6325030ab57d6e8