### PR TITLE
Add toast notifications

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -162,8 +162,21 @@ state.advanceDays = advanceDays;
 
 function addStatusMessage(msg) {
   state.statusMessage = msg;
-  const el = document.getElementById('operationalTips');
-  if(el) el.innerText = msg;
+
+  const container = document.getElementById('toastContainer');
+  if (!container) return;
+
+  const toast = document.createElement('div');
+  toast.className = 'toast-tip';
+  toast.textContent = msg;
+  container.appendChild(toast);
+
+  requestAnimationFrame(() => toast.classList.add('visible'));
+
+  setTimeout(() => {
+    toast.classList.remove('visible');
+    setTimeout(() => toast.remove(), 300);
+  }, 4000);
 }
 
 state.addStatusMessage = addStatusMessage;

--- a/index.html
+++ b/index.html
@@ -127,10 +127,6 @@
               </div>
             </div>
           </div>
-          <div id="tipsCard" class="tipsCard">
-            <h2>Operational Tips</h2>
-            <div id="operationalTips"></div>
-          </div>
         </div>
 
     </aside>
@@ -342,8 +338,9 @@
       <button id="closeMarketReportBtn" class="close-report-btn" onclick="closeMarketReport()">Back</button>
       <!-- Market tables and future graph placeholder will be injected into this container -->
       <div id="marketReportContent" class="market-report"></div>
-    </div>
-  <script type="module" src="script.js"></script>
+      </div>
+    <div id="toastContainer"></div>
+    <script type="module" src="script.js"></script>
   <script data-goatcounter="https://rwzephyr.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1383,6 +1383,39 @@ button:active {
   margin-top: 10px;
 }
 
+#toastContainer {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.toast-tip {
+  background: var(--bg-panel);
+  color: var(--text-light);
+  padding: 12px 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: auto;
+  max-width: 90vw;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.toast-tip.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 /* Responsive layout */
 @media (max-width: 700px) {
   #mainLayout {

--- a/ui.js
+++ b/ui.js
@@ -204,8 +204,6 @@ function updateDisplay(){
   }
 
   renderMap();
-  const tipsEl = document.getElementById('operationalTips');
-  if(tipsEl) tipsEl.innerText = state.statusMessage || 'All systems nominal.';
   const tsEl = document.querySelector('#marketReportContent .market-timestamp');
   if(tsEl) tsEl.innerText = `Prices last updated: ${state.lastMarketUpdateString}`;
   updateFeedPurchaseUI();


### PR DESCRIPTION
## Summary
- remove the operational tips panel from the sidebar
- show a toast message container at bottom of the page
- style toast UI
- display transient notifications via `addStatusMessage`
- clean up UI code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688320ca2c648329b54bf65ebf58e5ac