### PR TITLE
Add Logbook modal with milestone display

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
           <div id="mobileActionGroup" class="hidden">
             <button onclick="openMarketReport()">Market</button>
             <button onclick="openShipyard()">Shipyard</button>
+            <button onclick="openLogbook()" title="Open Logbook">Logbook</button>
             <button onclick="toggleDevTools()">⚙️</button>
           </div>
         </div>
@@ -332,6 +333,20 @@
           <div id="buildLockMessage" class="lock-message" style="display:none"></div>
           <button onclick="confirmCustomBuild()">Purchase</button>
         </div>
+      </div>
+    </div>
+    <div id="logbookModal" class="logbook-modal">
+      <button class="close-report-btn" onclick="closeLogbook()">Back</button>
+      <div id="logbookContent" class="logbook-content">
+        <h2>Logbook</h2>
+        <h3>Milestones</h3>
+        <div id="milestoneList"></div>
+        <h3>Species Info</h3>
+        <div id="speciesInfoPlaceholder"></div>
+        <h3>Contracts</h3>
+        <div id="contractsPlaceholder"></div>
+        <h3>Upgrades</h3>
+        <div id="upgradesPlaceholder"></div>
       </div>
     </div>
     <div id="marketReportPage" class="market-report-page">

--- a/style.css
+++ b/style.css
@@ -279,6 +279,40 @@ button:active {
   margin: 0 auto;
 }
 
+#logbookModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  background: var(--bg-darker);
+  color: var(--text-light);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 20px;
+  display: none;
+  z-index: 900;
+}
+
+#logbookModal.visible {
+  display: block;
+}
+
+#logbookContent {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.milestone-entry {
+  display: flex;
+  justify-content: space-between;
+  background: var(--bg-panel);
+  padding: 6px 8px;
+  border-radius: 6px;
+  margin-bottom: 4px;
+}
+
 #shipyardList {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/ui.js
+++ b/ui.js
@@ -21,6 +21,7 @@ import state, {
   estimateTravelTime,
   getSiteHarvestRate,
 } from "./gameState.js";
+import { milestones } from './milestones.js';
 
 const speciesColors = {
   shrimp: '#e74c3c',
@@ -1107,6 +1108,42 @@ function closeSpeciesData() {
   document.getElementById('speciesDataModal').classList.remove('visible');
 }
 
+function renderLogbook(){
+  const list = document.getElementById('milestoneList');
+  if(!list) return;
+  list.innerHTML = '';
+  milestones.forEach(m => {
+    const row = document.createElement('div');
+    row.className = 'milestone-entry';
+    const desc = document.createElement('span');
+    desc.textContent = m.description;
+    const status = document.createElement('span');
+    status.textContent = state.milestones[m.id] ? '✅' : '❌';
+    row.appendChild(desc);
+    row.appendChild(status);
+    list.appendChild(row);
+  });
+}
+
+function openLogbook(){
+  renderLogbook();
+  const modal = document.getElementById('logbookModal');
+  if(modal){
+    modal.classList.add('visible');
+    document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
+  }
+}
+
+function closeLogbook(){
+  const modal = document.getElementById('logbookModal');
+  if(modal){
+    modal.classList.remove('visible');
+    document.body.style.overflow = '';
+    document.documentElement.style.overflow = '';
+  }
+}
+
 function updateMarketCharts(){
   const charts = document.querySelectorAll('.market-chart');
   charts.forEach(c => {
@@ -1278,6 +1315,8 @@ export {
   updateSiteUpgrades,
   openDevModal,
   closeDevModal,
+  openLogbook,
+  closeLogbook,
   openSpeciesData,
   closeSpeciesData,
   updateFeedPurchaseUI,


### PR DESCRIPTION
## Summary
- add Logbook option to the tools menu
- build new `logbookModal` layout
- style logbook page and milestone entries
- support opening and closing the Logbook
- render milestone progress inside the Logbook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688336e6710c8329af0d8710a5434fdb