### PR TITLE
Add logbook section tabs

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -61,7 +61,8 @@ import {
   closeSiteManagement as uiCloseSiteManagement,
   updateSiteUpgrades,
   openDevModal as uiOpenDevModal,
-  closeDevModal as uiCloseDevModal
+  closeDevModal as uiCloseDevModal,
+  switchLogbookSection
 } from "./ui.js";
 
 function buyFeed(amount=20){
@@ -1190,6 +1191,7 @@ export {
   confirmCustomBuild,
   openMarketReport,
   closeMarketReport,
+  switchLogbookSection,
   openLogbook,
   closeLogbook,
   openSiteManagement,

--- a/index.html
+++ b/index.html
@@ -339,14 +339,24 @@
       <button class="close-report-btn" onclick="closeLogbook()">Back</button>
       <div id="logbookContent" class="logbook-content">
         <h2>Logbook</h2>
-        <h3>Milestones</h3>
-        <div id="milestoneList"></div>
-        <h3>Species Info</h3>
-        <div id="speciesInfoPlaceholder"></div>
-        <h3>Contracts</h3>
-        <div id="contractsPlaceholder"></div>
-        <h3>Upgrades</h3>
-        <div id="upgradesPlaceholder"></div>
+        <div id="tabBar">
+          <button id="tabMilestones" onclick="switchLogbookSection('milestones')">Milestones</button>
+          <button id="tabSpecies" onclick="switchLogbookSection('species')">Species Info</button>
+          <button id="tabContracts" onclick="switchLogbookSection('contracts')">Contracts</button>
+          <button id="tabUpgrades" onclick="switchLogbookSection('upgrades')">Upgrades</button>
+        </div>
+        <div id="logbookMilestones">
+          <div id="milestoneList"></div>
+        </div>
+        <div id="logbookSpecies" class="hidden">
+          <div id="speciesInfoPlaceholder"></div>
+        </div>
+        <div id="logbookContracts" class="hidden">
+          <div id="contractsPlaceholder"></div>
+        </div>
+        <div id="logbookUpgrades" class="hidden">
+          <div id="upgradesPlaceholder"></div>
+        </div>
       </div>
     </div>
     <div id="marketReportPage" class="market-report-page">

--- a/ui.js
+++ b/ui.js
@@ -105,6 +105,7 @@ function outsideSiteActionHandler(e){
 let lastSiteIndex = -1;
 let lastPenCount = 0;
 let lastVesselCount = 0;
+let logbookSection = 'milestones';
 
 // --- UPDATE UI ---
 function updateDisplay(){
@@ -1125,8 +1126,20 @@ function renderLogbook(){
   });
 }
 
+function switchLogbookSection(section){
+  logbookSection = section;
+  const sections = ['milestones','species','contracts','upgrades'];
+  sections.forEach(s => {
+    const content = document.getElementById('logbook' + capitalizeFirstLetter(s));
+    const tab = document.getElementById('tab' + capitalizeFirstLetter(s));
+    if(content) content.classList.toggle('hidden', s !== section);
+    if(tab) tab.classList.toggle('active', s === section);
+  });
+  if(section === 'milestones') renderLogbook();
+}
+
 function openLogbook(){
-  renderLogbook();
+  switchLogbookSection('milestones');
   const modal = document.getElementById('logbookModal');
   if(modal){
     modal.classList.add('visible');
@@ -1315,6 +1328,7 @@ export {
   updateSiteUpgrades,
   openDevModal,
   closeDevModal,
+  switchLogbookSection,
   openLogbook,
   closeLogbook,
   openSpeciesData,


### PR DESCRIPTION
## Summary
- add tab bar and section containers for Logbook
- implement section switching logic in UI
- export section switcher in actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68839348e35c8329b6a98432ef941f17