### PR TITLE
Fix circular module dependency

### DIFF
--- a/contracts.js
+++ b/contracts.js
@@ -1,27 +1,38 @@
-import state, { capitalizeFirstLetter } from './gameState.js';
+// Local state reference initialized via initContracts to avoid circular imports
+let state;
+let contracts = [];
 
-// Share the contracts array from game state so other modules reference the same list
-if(!state.contracts) state.contracts = [];
-const contracts = state.contracts;
+// Capitalize helper replicated here to keep module independent
+function capitalizeFirstLetter(str){
+  if(!str) return '';
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export function initContracts(gameState){
+  state = gameState;
+  if(!state.contracts) state.contracts = [];
+  contracts = state.contracts;
+  // seed a starter contract for the logbook
+  if(contracts.length === 0){
+    contracts.push({
+      id: 1,
+      species: 'shrimp',
+      type: 'biomass',
+      biomassGoalKg: 100,
+      destination: 'Capital Wharf',
+      startDay: state.totalDaysElapsed,
+      durationDays: 10,
+      rewardCash: 500,
+      flavorKey: 'basicDelivery',
+      status: 'active',
+    });
+  }
+}
 
 export const contractFlavors = {
   basicDelivery: "Ship {species} to {destination} on time.",
   bigOrder: "A bulk request for {species} has come in from {destination}.",
 };
-
-// Example starter contract so the Logbook has initial data
-contracts.push({
-  id: 1,
-  species: 'shrimp',
-  type: 'biomass',
-  biomassGoalKg: 100,
-  destination: 'Capital Wharf',
-  startDay: state.totalDaysElapsed,
-  durationDays: 10,
-  rewardCash: 500,
-  flavorKey: 'basicDelivery',
-  status: 'active',
-});
 
 export function getContractFlavor(contract){
   let text = contractFlavors[contract.flavorKey] || '';

--- a/gameState.js
+++ b/gameState.js
@@ -22,7 +22,7 @@ import {
   markets,
 } from './data.js';
 import { Site, Barge, Pen, Vessel } from './models.js';
-import { checkContractExpirations, contracts } from "./contracts.js";
+import { initContracts, checkContractExpirations } from "./contracts.js";
 
 // Core Game State wrapped in a mutable object so other modules can update it
 const state = {
@@ -58,8 +58,11 @@ const state = {
   lastMarketUpdateString: 'Spring 1, Year 1',
   harvestsCompleted: 0,
   milestones: {},
-  contracts,
+
 };
+
+// initialize contracts module with state reference
+initContracts(state);
 
 // Expose read-only accessors for external logic
 Object.defineProperties(window, {


### PR DESCRIPTION
## Summary
- refactor `contracts.js` to avoid importing `state` from `gameState.js`
- initialize contracts via a new `initContracts` function
- seed starter contract inside initialization function
- update `gameState.js` to call `initContracts` and remove contracts import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883a6b1c618832996ac49635b46c901