### PR TITLE
Make logbook species icons flat

### DIFF
--- a/style.css
+++ b/style.css
@@ -1423,8 +1423,13 @@ button:active {
   width: 56px;
   height: 56px;
   object-fit: contain;
-  border-radius: 4px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.6);
+  vertical-align: middle;
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .species-stats {


### PR DESCRIPTION
## Summary
- style `.logbook-species-icon` so species icons sit flush with text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883ada065608329853fd10145dc8ef3