### PR TITLE
Implement fish buffer retention after cancel

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -521,6 +521,7 @@ function harvestPen(amount=null){
     if(!vessel.cargo[pen.species]) vessel.cargo[pen.species] = 0;
     vessel.harvestProgress = 0;
     vessel.harvestFishBuffer = 0;
+    const lockedWeight = pen.averageWeight;
     const startFishCount = pen.fishCount;
     let last = Date.now();
     const updateEta = () => {
@@ -547,6 +548,9 @@ function harvestPen(amount=null){
       if(remove>0){
         pen.fishCount -= remove;
         vessel.harvestFishBuffer -= remove;
+        for(let i=0;i<remove;i++){
+          vessel.fishBuffer.push({ weight: lockedWeight });
+        }
         if(pen.fishCount<=0) pen.averageWeight = 0;
       }
       updateEta();
@@ -1026,6 +1030,7 @@ function loadGame() {
         Object.defineProperty(v, 'harvestTimeout', { value: null, writable: true, enumerable: false });
         Object.defineProperty(v, 'harvestProgress', { value: 0, writable: true, enumerable: false });
         Object.defineProperty(v, 'harvestFishBuffer', { value: 0, writable: true, enumerable: false });
+        Object.defineProperty(v, 'fishBuffer', { value: [], writable: true, enumerable: false });
         Object.defineProperty(v, 'harvestingPenIndex', { value: null, writable: true, enumerable: false });
         Object.defineProperty(v, 'travelInterval', { value: null, writable: true, enumerable: false });
         Object.defineProperty(v, 'offloadInterval', { value: null, writable: true, enumerable: false });

--- a/models.js
+++ b/models.js
@@ -102,6 +102,7 @@ export class Vessel {
     Object.defineProperty(this, 'harvestTimeout', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestProgress', { value: 0, writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestFishBuffer', { value: 0, writable: true, enumerable: false });
+    Object.defineProperty(this, 'fishBuffer', { value: [], writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestingPenIndex', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'travelInterval', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'offloadInterval', { value: null, writable: true, enumerable: false });

--- a/ui.js
+++ b/ui.js
@@ -891,6 +891,7 @@ function finishOffloading(vessel, market, canceled=false){
     vessel.cargo = {};
     vessel.cargoSpecies = null;
     vessel.currentBiomassLoad = 0;
+    vessel.fishBuffer = [];
     if(market && market.daysSinceSale){
       for(const sp in prices){ market.daysSinceSale[sp] = 0; }
     }


### PR DESCRIPTION
## Summary
- keep prior fishBuffer data when starting new harvests
- stop clearing fishBuffer on harvest cancel
- flush fishBuffer after offloading cargo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883b0cbbae08329863052178f8b4182