### PR TITLE
Fix offload loop termination

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -899,7 +899,9 @@ function startOffloading(vessel, market){
     }
     updateEta();
     updateDisplay();
-    if(vessel.currentBiomassLoad <= 0){
+    const epsilon = 0.0001;
+    if(vessel.currentBiomassLoad <= epsilon || vessel.fishBuffer.length === 0){
+      vessel.currentBiomassLoad = 0;
       finishOffloading(vessel, market);
     }
   },250);


### PR DESCRIPTION
## Summary
- stop offload interval when cargo is effectively empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e2448ce88329acf72a423a05c890