### PR TITLE
Fix rounding issue when harvesting fish

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -561,6 +561,12 @@ function harvestPen(amount=null){
         // ensure final fish count accounts for rounding
         pen.fishCount = Math.max(0, startFishCount - fishNum);
         if(pen.fishCount === 0) pen.averageWeight = 0;
+        const leftover = Math.round(vessel.harvestFishBuffer);
+        if(leftover > 0){
+          for(let i=0; i<leftover; i++){
+            vessel.fishBuffer.push({ species: pen.species, weight: lockedWeight });
+          }
+        }
         vessel.harvestFishBuffer = 0;
         pen.locked = false;
         vessel.harvestingPenIndex = null;


### PR DESCRIPTION
## Summary
- ensure leftover fractional fish are added to the vessel when harvest completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e8d5b488832980f26b68c224b777