### PR TITLE
Add contract delivery via vessels

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,6 +236,14 @@
       </div>
     </div>
 
+    <div id="contractDeliveryModal">
+      <div id="contractDeliveryContent">
+        <h2>Select Vessel</h2>
+        <div id="contractDeliveryOptions"></div>
+        <button onclick="closeContractDeliveryModal()">Cancel</button>
+      </div>
+    </div>
+
     <div id="devModal">
       <div id="devModalContent">
         <h2>Developer Tools</h2>

--- a/models.js
+++ b/models.js
@@ -97,6 +97,7 @@ export class Vessel {
 
     this.unloading = false;
     this.offloadRevenue = 0;
+    this.deliveringContractId = null;
 
     // timers and progress (non-enumerable so they aren't saved)
     Object.defineProperty(this, 'harvestInterval', { value: null, writable: true, enumerable: false });
@@ -109,5 +110,6 @@ export class Vessel {
     Object.defineProperty(this, 'offloadInterval', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'offloadPrices', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'offloadMarket', { value: null, writable: true, enumerable: false });
+    Object.defineProperty(this, 'contractInterval', { value: null, writable: true, enumerable: false });
   }
 }

--- a/style.css
+++ b/style.css
@@ -217,7 +217,8 @@ button:active {
 #sellModal,
 #moveModal,
 #renameModal,
-#bargeUpgradeModal {
+#bargeUpgradeModal,
+#contractDeliveryModal {
   position: fixed;
   top: 0;
   left: 0;
@@ -253,7 +254,8 @@ button:active {
 #sellModal.visible,
 #moveModal.visible,
 #renameModal.visible,
-#bargeUpgradeModal.visible {
+#bargeUpgradeModal.visible,
+#contractDeliveryModal.visible {
   display: flex;
 }
 
@@ -268,7 +270,8 @@ button:active {
 #sellModalContent,
 #moveModalContent,
 #renameModalContent,
-#bargeUpgradeModalContent {
+#bargeUpgradeModalContent,
+#contractDeliveryContent {
   background: var(--modal-bg);
   color: var(--text-light);
   padding: 20px;

--- a/ui.js
+++ b/ui.js
@@ -408,7 +408,7 @@ function renderVesselGrid(){
     card.querySelector('.vessel-tier').textContent = vesselTiers[vessel.tier].name;
     card.querySelector('.vessel-location').textContent = vessel.location;
     const statusEl = card.querySelector('.vessel-status');
-    let status = vessel.isHarvesting ? 'Harvesting' : vessel.unloading ? 'Unloading' : (vessel.location.startsWith('Traveling') ? 'Traveling' : 'Idle');
+    let status = vessel.isHarvesting ? 'Harvesting' : vessel.unloading ? 'Unloading' : vessel.deliveringContractId ? 'Delivering' : (vessel.location.startsWith('Traveling') ? 'Traveling' : 'Idle');
     if(vessel.actionEndsAt && vessel.actionEndsAt > Date.now()){
       const eta = Math.max(0, (vessel.actionEndsAt - Date.now())/1000);
       status += ` (${eta.toFixed(0)}s)`;
@@ -429,16 +429,16 @@ function renderVesselGrid(){
     if(infoEl){ infoEl.textContent = infoStr; infoEl.title = infoStr; }
     const harvestBtn = card.querySelector('.harvest-btn');
     harvestBtn.onclick = ()=>{ state.currentVesselIndex = idx; openHarvestModal(idx); };
-    harvestBtn.style.display = (vessel.isHarvesting || vessel.unloading) ? 'none' : 'block';
+    harvestBtn.style.display = (vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId) ? 'none' : 'block';
     const moveBtn = card.querySelector('.move-btn');
     moveBtn.onclick = ()=>{ state.currentVesselIndex = idx; openMoveVesselModal(); };
-    moveBtn.disabled = vessel.isHarvesting || vessel.unloading;
+    moveBtn.disabled = vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId;
     const sellBtn = card.querySelector('.sell-btn');
     sellBtn.onclick = ()=>{ state.currentVesselIndex = idx; openSellModal(); };
-    sellBtn.disabled = vessel.isHarvesting || vessel.unloading;
+    sellBtn.disabled = vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId;
     const upBtn = card.querySelector('.upgrade-btn');
     upBtn.onclick = ()=>{ state.currentVesselIndex = idx; upgradeVessel(); };
-    upBtn.disabled = vessel.isHarvesting || vessel.unloading;
+    upBtn.disabled = vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId;
     const cancelBtn = card.querySelector('.cancel-btn');
     cancelBtn.onclick = ()=>{
       state.currentVesselIndex = idx;
@@ -465,7 +465,7 @@ function updateVesselCards(){
     card.querySelector('.vessel-tier').textContent = vesselTiers[vessel.tier].name;
     card.querySelector('.vessel-location').textContent = vessel.location;
     const statusEl = card.querySelector('.vessel-status');
-    let status = vessel.isHarvesting ? 'Harvesting' : vessel.unloading ? 'Unloading' : (vessel.location.startsWith('Traveling') ? 'Traveling' : 'Idle');
+    let status = vessel.isHarvesting ? 'Harvesting' : vessel.unloading ? 'Unloading' : vessel.deliveringContractId ? 'Delivering' : (vessel.location.startsWith('Traveling') ? 'Traveling' : 'Idle');
     if(vessel.actionEndsAt && vessel.actionEndsAt > Date.now()){
       const eta = Math.max(0, (vessel.actionEndsAt - Date.now())/1000);
       status += ` (${eta.toFixed(0)}s)`;
@@ -486,15 +486,15 @@ function updateVesselCards(){
     if(infoEl2){ infoEl2.textContent = infoStr2; infoEl2.title = infoStr2; }
     const harvestBtn2 = card.querySelector('.harvest-btn');
     harvestBtn2.onclick = ()=>{ state.currentVesselIndex = idx; openHarvestModal(idx); };
-    harvestBtn2.style.display = (vessel.isHarvesting || vessel.unloading) ? 'none' : 'block';
+    harvestBtn2.style.display = (vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId) ? 'none' : 'block';
     const moveBtn2 = card.querySelector('.move-btn');
-    moveBtn2.disabled = vessel.isHarvesting || vessel.unloading;
+    moveBtn2.disabled = vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId;
     moveBtn2.onclick = ()=>{ state.currentVesselIndex = idx; openMoveVesselModal(); };
     const sellBtn2 = card.querySelector('.sell-btn');
-    sellBtn2.disabled = vessel.isHarvesting || vessel.unloading;
+    sellBtn2.disabled = vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId;
     sellBtn2.onclick = ()=>{ state.currentVesselIndex = idx; openSellModal(); };
     const upBtn2 = card.querySelector('.upgrade-btn');
-    upBtn2.disabled = vessel.isHarvesting || vessel.unloading;
+    upBtn2.disabled = vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId;
     upBtn2.onclick = ()=>{ state.currentVesselIndex = idx; upgradeVessel(); };
     const cancelBtn = card.querySelector('.cancel-btn');
     cancelBtn.onclick = ()=>{
@@ -704,7 +704,8 @@ function openHarvestModal(vIdx){
   state.currentVesselIndex = vIdx;
   const site = state.sites[state.currentSiteIndex];
   const vessel = state.vessels[vIdx];
-  if(vessel.isHarvesting) return openModal('Vessel currently harvesting.');
+  if(vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId)
+    return openModal('Vessel currently busy.');
   const select = document.getElementById('harvestPenSelect');
   select.innerHTML = '';
   site.pens.forEach((pen, idx)=>{
@@ -734,7 +735,8 @@ function openSellModal(){
   const optionsDiv = document.getElementById('sellOptions');
   optionsDiv.innerHTML = '';
   const vessel = state.vessels[state.currentVesselIndex];
-  if(vessel.isHarvesting) return openModal('Vessel currently harvesting.');
+  if(vessel.isHarvesting || vessel.unloading || vessel.deliveringContractId)
+    return openModal('Vessel currently busy.');
   markets.forEach((m,idx)=>{
     const btn = document.createElement('button');
     const price = estimateSellPrice(vessel, m);


### PR DESCRIPTION
## Summary
- allow vessels to deliver cargo directly to contracts
- show delivery option for each contract if a vessel can fulfill it
- notify when a harvest enables contract fulfillment
- lock vessels during contract delivery and award bonus payout
- include modal UI for selecting a delivery vessel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883edab89e48329b7c47507bf13cfc2