### PR TITLE
Update licence dropdown UI

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -61,6 +61,8 @@ import {
   openSiteManagement as uiOpenSiteManagement,
   closeSiteManagement as uiCloseSiteManagement,
   updateSiteUpgrades,
+  updateLicenseDropdown,
+  updateSiteLicenses,
   openDevModal as uiOpenDevModal,
   closeDevModal as uiCloseDevModal,
   switchLogbookSection
@@ -96,6 +98,8 @@ function purchaseLicense(sp){
   state.cash -= cost;
   site.licenses.push(sp);
   updateDisplay();
+  updateSiteLicenses();
+  updateLicenseDropdown();
   openModal('License purchased successfully');
 }
 

--- a/index.html
+++ b/index.html
@@ -288,7 +288,12 @@
         <button class="close-report-btn" onclick="closeSiteManagement()">Back</button>
         <h2>Site Management – <span id="siteManagementSiteName"></span></h2>
         <div id="siteLicenses"></div>
-        <section id="licenseShop"></section>
+        <section id="licenseShop">
+          <div class="site-switcher">
+            <button id="licenseDropdownBtn" onclick="toggleLicenseList()">Buy License ⌄</button>
+            <div id="licenseDropdownList" class="site-list hidden"></div>
+          </div>
+        </section>
         <h3>Site Upgrades</h3>
         <div id="siteUpgrades" class="site-upgrade-grid">
           <div class="site-upgrade-card">


### PR DESCRIPTION
## Summary
- switch licence shop to a custom dropdown like site selector
- update licence UI only when needed
- refresh licence list when sites or licences change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885517f0fd483298256f91bc9575a99