### PR TITLE
Add icons to license dropdown

### DIFF
--- a/style.css
+++ b/style.css
@@ -1098,6 +1098,23 @@ button:active {
   pointer-events: none;
 }
 
+/* License dropdown specific styling */
+#licenseDropdownList {
+  min-width: 220px;
+}
+
+#licenseDropdownList div {
+  display: flex;
+  align-items: center;
+}
+
+#licenseDropdownList img {
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  pointer-events: none;
+}
+
 #mobileActionGroup {
   position: absolute;
   right: 0;

--- a/ui.js
+++ b/ui.js
@@ -251,7 +251,13 @@ function populateLicenseDropdown(){
     const data = speciesData[sp];
     if(!site.licenses.includes(sp) && data.licenseCost>0){
       const item = document.createElement('div');
-      item.textContent = `${capitalizeFirstLetter(sp)} - $${data.licenseCost}`;
+      const icon = document.createElement('img');
+      icon.src = `assets/species-icons/${sp}.png`;
+      icon.alt = sp;
+      item.appendChild(icon);
+      const label = document.createElement('span');
+      label.textContent = `${capitalizeFirstLetter(sp)} - $${data.licenseCost}`;
+      item.appendChild(label);
       item.onclick = () => {
         purchaseLicense(sp);
         const list = document.getElementById('licenseDropdownList');


### PR DESCRIPTION
## Summary
- enlarge Buy License dropdown to fit icons and price text
- add species icon next to each dropdown option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688557cf7d208329a44798f2ef5f59d4