### PR TITLE
Implement contract tiers

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -991,6 +991,9 @@ function saveGame() {
     sites: state.sites,
     vessels: state.vessels,
     harvestsCompleted: state.harvestsCompleted,
+    contracts: state.contracts,
+    contractsCompletedByTier: state.contractsCompletedByTier,
+    unlockedContractTiers: state.unlockedContractTiers,
     milestones: state.milestones,
     marketStates: markets.map(m => ({
       name: m.name,
@@ -1030,6 +1033,9 @@ function loadGame() {
       state.cash = obj.cash ?? state.cash;
       state.penPurchaseCost = obj.penPurchaseCost ?? state.penPurchaseCost;
       state.harvestsCompleted = obj.harvestsCompleted ?? 0;
+      state.contracts = obj.contracts ?? state.contracts;
+      state.contractsCompletedByTier = obj.contractsCompletedByTier ?? {};
+      state.unlockedContractTiers = obj.unlockedContractTiers ?? [0];
       state.milestones = obj.milestones ?? {};
       state.sites = obj.sites;
       state.sites.forEach(s => { if(!s.location) s.location = { x: Math.random()*100, y: Math.random()*100 }; });
@@ -1106,6 +1112,7 @@ function loadGame() {
     console.error('Load failed', e);
   }
   setupMarketData();
+  initContracts(state);
   state.generateShipyardInventory();
   initMilestones();
 }

--- a/data.js
+++ b/data.js
@@ -225,5 +225,11 @@ export const markets = [
   }
 ];
 
+export const contractBuyers = [
+  { name: 'Local Co-op', tiers: [0] },
+  { name: 'Atlantic Exports', tiers: [1] },
+  { name: 'NorFed Genetics', tiers: [2] }
+];
+
 
 

--- a/gameState.js
+++ b/gameState.js
@@ -22,7 +22,7 @@ import {
   markets,
 } from './data.js';
 import { Site, Barge, Pen, Vessel } from './models.js';
-import { initContracts, checkContractExpirations } from "./contracts.js";
+import { initContracts, checkContractExpirations, generateDailyContracts } from "./contracts.js";
 
 // Core Game State wrapped in a mutable object so other modules can update it
 const state = {
@@ -58,6 +58,8 @@ const state = {
   lastMarketUpdateString: 'Spring 1, Year 1',
   harvestsCompleted: 0,
   milestones: {},
+  contractsCompletedByTier: {},
+  unlockedContractTiers: [0],
 
 };
 
@@ -156,6 +158,7 @@ function advanceDay() {
   }
   updateMarketPrices();
   checkContractExpirations();
+  generateDailyContracts();
 }
 
 state.advanceDay = advanceDay;


### PR DESCRIPTION
## Summary
- add contract tier metadata and buyers
- generate daily contracts weighted by tier
- track contract completions and unlock higher tiers
- persist contract progress to saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856bd7becc8329962a2d94a3fcb808