### PR TITLE
Fix sale price locking logic

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -335,9 +335,18 @@ function estimateSellPrice(vessel, market){
   if(vessel.fishBuffer){
     vessel.fishBuffer.forEach(fish=>{
       const sp = fish.species || vessel.cargoSpecies;
-      const base = speciesData[sp]?.marketPrice || 0;
-      const mod = market.modifiers[sp] || 1;
-      total += fish.weight * base * mod;
+      let price = fish.salePrice;
+      if(price === undefined){
+        const marketPrice = market.prices?.[sp];
+        if(marketPrice !== undefined){
+          price = marketPrice;
+        } else {
+          const base = speciesData[sp]?.marketPrice || 0;
+          const mod = market.modifiers[sp] || 1;
+          price = base * mod;
+        }
+      }
+      total += fish.weight * price;
     });
   }
   return total;


### PR DESCRIPTION
## Summary
- revert harvest price snapshot approach
- lock price for each fish when offloading begins
- update estimateSellPrice to use locked sale prices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688578e679ac8329b67bfb57ad5fffb1