### PR TITLE
Fix missing cargo data on save

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1051,7 +1051,7 @@ function loadGame() {
         Object.defineProperty(v, 'harvestTimeout', { value: null, writable: true, enumerable: false });
         Object.defineProperty(v, 'harvestProgress', { value: 0, writable: true, enumerable: false });
         Object.defineProperty(v, 'harvestFishBuffer', { value: 0, writable: true, enumerable: false });
-        Object.defineProperty(v, 'fishBuffer', { value: [], writable: true, enumerable: false });
+        if(!v.fishBuffer) v.fishBuffer = [];
         Object.defineProperty(v, 'harvestingPenIndex', { value: null, writable: true, enumerable: false });
         Object.defineProperty(v, 'travelInterval', { value: null, writable: true, enumerable: false });
         Object.defineProperty(v, 'offloadInterval', { value: null, writable: true, enumerable: false });

--- a/models.js
+++ b/models.js
@@ -104,7 +104,8 @@ export class Vessel {
     Object.defineProperty(this, 'harvestTimeout', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestProgress', { value: 0, writable: true, enumerable: false });
     Object.defineProperty(this, 'harvestFishBuffer', { value: 0, writable: true, enumerable: false });
-    Object.defineProperty(this, 'fishBuffer', { value: [], writable: true, enumerable: false });
+    // fishBuffer needs to persist so make it enumerable
+    this.fishBuffer = [];
     Object.defineProperty(this, 'harvestingPenIndex', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'travelInterval', { value: null, writable: true, enumerable: false });
     Object.defineProperty(this, 'offloadInterval', { value: null, writable: true, enumerable: false });


### PR DESCRIPTION
## Summary
- ensure vessel `fishBuffer` persists between saves
- restore `fishBuffer` when loading saved game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885844c7e248329b96a3cd8ba3908ff