### PR TITLE
Increase starting cash

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -26,7 +26,7 @@ import { initContracts, checkContractExpirations, generateDailyContracts } from 
 
 // Core Game State wrapped in a mutable object so other modules can update it
 const state = {
-  cash: 200,
+  cash: 1000,
   BASE_HARVEST_RATE: 5, // kg per second
   HARVESTER_RATE: 10, // additional kg/s per harvester
   penPurchaseCost: 1000,


### PR DESCRIPTION
## Summary
- bump player's starting cash from $200 to $1000

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885affb6fa883299c60263fb465685f