### PR TITLE
Add back button to bank modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,7 @@
 
     <div id="bankModal">
       <div id="bankModalContent">
+        <button class="close-report-btn" onclick="closeBank()">Back</button>
         <h2>Bank</h2>
         <p>Deposit: $<span id="bankDepositDisplay">0.00</span> (2% daily interest)</p>
         <input id="bankDepositInput" type="number" min="0" />

--- a/ui.js
+++ b/ui.js
@@ -1277,6 +1277,15 @@ function openBank(){
   }
 }
 
+function closeBank(){
+  const modal = document.getElementById('bankModal');
+  if(modal){
+    modal.classList.remove('visible');
+    document.body.style.overflow = '';
+    document.documentElement.style.overflow = '';
+  }
+}
+
 function handleDeposit() {
   const amount = parseFloat(document.getElementById('bankDepositInput').value);
   depositToBank(amount);
@@ -1650,6 +1659,7 @@ export {
   openMarketReport,
   closeMarketReport,
   openBank,
+  closeBank,
   handleDeposit,
   handleWithdraw,
   handleTakeLoan,


### PR DESCRIPTION
## Summary
- allow closing bank modal by adding back button
- implement `closeBank` handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c403dc4083299253082828b0e6b5