### PR TITLE
Reorganize top bar icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,20 +13,12 @@
     <!-- Top bar grouped for easier styling -->
     <div id="topBar">
       <div class="top-bar-group" id="siteGroup">
-        <img src="assets/general-icons/siteactions.png" alt="Site" class="icon-inline" />
         <strong>Site:</strong>
         <div class="site-switcher">
           <button id="siteNameBtn" onclick="toggleSiteList()">
             <span id="siteName">-</span> ⌄
           </button>
           <div id="siteDropdownList" class="site-list hidden"></div>
-        </div>
-        <div class="mobile-action-wrapper" id="siteActionGroup">
-          <img id="siteActionToggle" src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-button" onclick="toggleSiteActions()" />
-          <div id="siteActionMenu" class="hidden">
-            <button onclick="buyNewSite()">+ New Site</button>
-            <button onclick="openSiteManagement()">Manage Site</button>
-          </div>
         </div>
       </div>
       <div class="top-bar-group" id="statusGroup">
@@ -38,8 +30,14 @@
           <span id="playButton" class="time-btn" title="Resume" onclick="resumeTime()">▶️</span>
         </div>
       </div>
-      <div class="top-bar-group" id="toolsGroup">
-        <img src="assets/general-icons/browser.png" alt="Tools" class="icon-inline" />
+      <div id="actionIconsWrapper">
+        <div class="mobile-action-wrapper" id="siteActionGroup">
+          <img id="siteActionToggle" src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-button" onclick="toggleSiteActions()" />
+          <div id="siteActionMenu" class="hidden">
+            <button onclick="buyNewSite()">+ New Site</button>
+            <button onclick="openSiteManagement()">Manage Site</button>
+          </div>
+        </div>
         <div class="mobile-action-wrapper" id="toolsActionGroup">
           <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" onclick="toggleMobileActions()" />
           <div id="mobileActionGroup" class="hidden">
@@ -49,9 +47,6 @@
             <button onclick="toggleDevTools()">⚙️</button>
           </div>
         </div>
-      </div>
-      <div class="top-bar-group" id="bankGroup">
-        <img src="assets/general-icons/bank.png" alt="Financials" class="icon-inline" />
         <div class="mobile-action-wrapper" id="bankActionGroup">
           <img id="bankActionToggle" src="assets/general-icons/bank.png"
                alt="Bank" class="icon-button" onclick="toggleBankActions()" />
@@ -62,7 +57,6 @@
           </div>
         </div>
       </div>
-      <div id="mobileIconBar" class="icon-action-bar"></div>
     </div>
     </div>
   </header>

--- a/script.js
+++ b/script.js
@@ -16,32 +16,9 @@ function adjustHeaderPadding(){
 
 window.addEventListener('resize', adjustHeaderPadding);
 
-function reflowTopBar(){
-  const mobileBreak = 500;
-  const siteGroup = document.getElementById('siteGroup');
-  const siteActions = document.getElementById('siteActionGroup');
-  const toolsGroup = document.getElementById('toolsGroup');
-  const toolsActions = document.getElementById('toolsActionGroup');
-  const bankGroup = document.getElementById('bankGroup');
-  const bankActions = document.getElementById('bankActionGroup');
-  const mobileBar = document.getElementById('mobileIconBar');
-  if(!siteGroup || !siteActions || !toolsGroup || !toolsActions || !bankGroup || !bankActions || !mobileBar) return;
-  if(window.innerWidth <= mobileBreak){
-    if(!mobileBar.contains(siteActions)) mobileBar.appendChild(siteActions);
-    if(!mobileBar.contains(toolsActions)) mobileBar.appendChild(toolsActions);
-    if(!mobileBar.contains(bankActions)) mobileBar.appendChild(bankActions);
-  } else {
-    if(!siteGroup.contains(siteActions)) siteGroup.appendChild(siteActions);
-    if(!toolsGroup.contains(toolsActions)) toolsGroup.appendChild(toolsActions);
-    if(!bankGroup.contains(bankActions)) bankGroup.appendChild(bankActions);
-  }
-}
-
-window.addEventListener('resize', reflowTopBar);
 
 document.addEventListener('DOMContentLoaded', () => {
   adjustHeaderPadding();
-  reflowTopBar();
   actions.loadGame();
   initMilestones();
   ui.updateDisplay();

--- a/style.css
+++ b/style.css
@@ -1335,22 +1335,14 @@ html.modal-open {
   pointer-events: auto;
 }
 
-.icon-action-bar {
+#actionIconsWrapper {
   display: flex;
-  justify-content: center;
+  align-items: center;
   gap: 16px;
-  margin-top: 6px;
-}
-
-#mobileIconBar {
-  display: none;
 }
 
 @media (max-width: 500px) {
-  #mobileIconBar {
-    display: flex;
-  }
-  .icon-action-bar {
+  #actionIconsWrapper {
     gap: 8px;
   }
   .icon-button {
@@ -1420,50 +1412,6 @@ html.modal-open {
   color: var(--bg-darker);
 }
 
-@media (min-width: 601px) {
-  #mobileActionToggle {
-    display: none;
-  }
-  #mobileActionGroup {
-    position: static;
-    flex-direction: row;
-    opacity: 1;
-    transform: none;
-    pointer-events: auto;
-    display: flex;
-  }
-  #mobileActionGroup.hidden {
-    display: flex !important;
-  }
-  #siteActionToggle {
-    display: none;
-  }
-  #siteActionMenu {
-    position: static;
-    flex-direction: row;
-    opacity: 1;
-    transform: none;
-    pointer-events: auto;
-    display: flex;
-  }
-  #siteActionMenu.hidden {
-    display: flex !important;
-  }
-  #bankActionToggle {
-    display: none;
-  }
-  #bankActionMenu {
-    position: static;
-    flex-direction: row;
-    opacity: 1;
-    transform: none;
-    pointer-events: auto;
-    display: flex;
-  }
-  #bankActionMenu.hidden {
-    display: flex !important;
-  }
-}
 
 /* Mobile sidebar behavior */
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- group all action icons in a dedicated container
- remove desktop-only menu behavior so menus toggle on click for all sizes
- drop unused reflowTopBar logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885cf40ea748329910dec76cccf972e