### PR TITLE
Add Quick Status icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,86 +57,99 @@
           </div>
         </div>
       </div>
+      <div id="quickStatusBar">
+        <div id="feedStatusIcon" class="status-icon" onclick="toggleStatusPanel('feed')">
+          <img src="assets/general-icons/bulkbag.png" alt="Feed">
+          <div class="status-label">Feed</div>
+          <div class="status-badge" id="feedStatusBadge">0/0kg</div>
+        </div>
+        <div id="bargeStatusIcon" class="status-icon" onclick="toggleStatusPanel('barge')">
+          <img src="assets/general-icons/cagesystem.png" alt="Barge">
+          <div class="status-label">Barge</div>
+          <div class="status-badge" id="bargeStatusBadge"></div>
+        </div>
+        <div id="staffStatusIcon" class="status-icon" onclick="toggleStatusPanel('staff')">
+          <img src="assets/general-icons/bulkbag.png" alt="Staff">
+          <div class="status-label">Staff</div>
+          <div class="status-badge" id="staffStatusBadge"></div>
+        </div>
+      </div>
     </div>
     </div>
   </header>
 
-  <main id="mainLayout">
-      <aside id="rightSidebar">
-        <!-- Status cards -->
-        <div id="cardContainer" class="cardContainer">
-          <div id="feedOverviewCard" class="logisticsCard">
-            <h2>Feed Management</h2>
-            <div class="progressBar"><div id="feedProgress" class="progress"></div></div>
-            <div><span id="totalFeed">0</span> / <span id="totalFeedCapacity">0</span> kg</div>
-            <div id="feedPurchaseSection" class="feed-purchase">
-              <div class="feed-purchase-row">
-                <input type="range" id="feedPurchaseSlider" min="0" value="0" step="1" oninput="syncFeedPurchase('slider')">
-                <input type="number" id="feedPurchaseInput" min="0" value="0" step="1" oninput="syncFeedPurchase('input')">
-              </div>
-              <div id="feedPurchaseCost">Cost: $0.00</div>
-              <div class="feed-purchase-buttons">
-                <button onclick="confirmBuyFeed()">Buy</button>
-                <button onclick="setFeedPurchaseMax()">Buy Max</button>
-              </div>
-            </div>
-          </div>
-          <div id="bargeCard" class="bargeCard">
-            <h2>Barge Status</h2>
-            <div>
-              <button class="staff-button" onclick="previousBarge()">⟵</button>
-              Barge <span id="bargeIndex">1</span>/<span id="bargeCount">1</span>
-              <button class="staff-button" onclick="nextBarge()">⟶</button>
-            </div>
-            <div>Feeders: <span id="bargeFeedersUsed">0</span>/<span id="bargeFeederLimit">0</span> (Max Tier <span id="bargeMaxFeederTier">0</span>)</div>
-            <div>Feed: <span id="bargeFeed">0</span> / <span id="bargeFeedCapacity">0</span> kg</div>
-            <div>Silo Capacity: <span id="bargeSiloCapacity">0</span> kg</div>
-            <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
-            <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
-            <div id="bargeHousingInfo"></div>
-            <button class="staff-button" onclick="openBargeUpgradeModal()">Barge Upgrades</button>
-          </div>
-          <div id="staffCard" class="staffCard">
-            <h2>Staffing</h2>
-            <div class="staff-stats">
-              <img src="assets/general-icons/farmer.png" alt="Staff icon" class="staff-icon">
-              <div class="staff-info">
-                <div>Total: <span id="staffTotal">0</span> / <span id="staffCapacity">0</span></div>
-                <div>Unassigned: <span id="staffUnassigned">0</span></div>
-              </div>
-            </div>
-            <div class="staff-buttons">
-              <button class="staff-button" onclick="hireStaff()">&#x2795; Hire ($500)</button>
-              <button class="staff-button" onclick="fireStaff()">&#x1f5d1; Fire</button>
-            </div>
-            <div class="staff-role">
-              <span>Feeders:</span>
-              <div class="role-controls">
-                <button class="staff-button" onclick="unassignStaff('feeder')" aria-label="Remove feeder">&#x2212;</button>
-                <span id="staffFeeders">0</span>
-                <button class="staff-button" onclick="assignStaff('feeder')" aria-label="Add feeder">&#x2b;</button>
-              </div>
-            </div>
-            <div class="staff-role">
-              <span>Harvesters:</span>
-              <div class="role-controls">
-                <button class="staff-button" onclick="unassignStaff('harvester')" aria-label="Remove harvester">&#x2212;</button>
-                <span id="staffHarvesters">0</span>
-                <button class="staff-button" onclick="assignStaff('harvester')" aria-label="Add harvester">&#x2b;</button>
-              </div>
-            </div>
-            <div class="staff-role">
-              <span>Feed Managers:</span>
-              <div class="role-controls">
-                <button class="staff-button" onclick="unassignStaff('feedManager')" aria-label="Remove feed manager">&#x2212;</button>
-                <span id="staffManagers">0</span>
-                <button class="staff-button" onclick="assignStaff('feedManager')" aria-label="Add feed manager">&#x2b;</button>
-              </div>
-            </div>
-          </div>
-        </div>
+  <div id="feedPanel" class="status-panel">
+    <h2>Feed Management</h2>
+    <div class="progressBar"><div id="feedProgress" class="progress"></div></div>
+    <div><span id="totalFeed">0</span> / <span id="totalFeedCapacity">0</span> kg</div>
+    <div id="feedPurchaseSection" class="feed-purchase">
+      <div class="feed-purchase-row">
+        <input type="range" id="feedPurchaseSlider" min="0" value="0" step="1" oninput="syncFeedPurchase('slider')">
+        <input type="number" id="feedPurchaseInput" min="0" value="0" step="1" oninput="syncFeedPurchase('input')">
+      </div>
+      <div id="feedPurchaseCost">Cost: $0.00</div>
+      <div class="feed-purchase-buttons">
+        <button onclick="confirmBuyFeed()">Buy</button>
+        <button onclick="setFeedPurchaseMax()">Buy Max</button>
+      </div>
+    </div>
+  </div>
 
-    </aside>
+  <div id="bargePanel" class="status-panel">
+    <h2>Barge Management</h2>
+    <div>
+      <button class="staff-button" onclick="previousBarge()">⟵</button>
+      Barge <span id="bargeIndex">1</span>/<span id="bargeCount">1</span>
+      <button class="staff-button" onclick="nextBarge()">⟶</button>
+    </div>
+    <div>Feeders: <span id="bargeFeedersUsed">0</span>/<span id="bargeFeederLimit">0</span> (Max Tier <span id="bargeMaxFeederTier">0</span>)</div>
+    <div>Feed: <span id="bargeFeed">0</span> / <span id="bargeFeedCapacity">0</span> kg</div>
+    <div>Silo Capacity: <span id="bargeSiloCapacity">0</span> kg</div>
+    <div>Staff: <span id="bargeStaffCount">0</span> / <span id="bargeStaffCapacity">0</span></div>
+    <div>Unassigned: <span id="bargeStaffUnassigned">0</span></div>
+    <div id="bargeHousingInfo"></div>
+    <button class="staff-button" onclick="openBargeUpgradeModal()">Barge Upgrades</button>
+  </div>
+
+  <div id="staffPanel" class="status-panel">
+    <h2>Staffing</h2>
+    <div class="staff-stats">
+      <div class="staff-info">
+        <div>Total: <span id="staffTotal">0</span> / <span id="staffCapacity">0</span></div>
+        <div>Unassigned: <span id="staffUnassigned">0</span></div>
+      </div>
+    </div>
+    <div class="staff-buttons">
+      <button class="staff-button" onclick="hireStaff()">&#x2795; Hire ($500)</button>
+      <button class="staff-button" onclick="fireStaff()">&#x1f5d1; Fire</button>
+    </div>
+    <div class="staff-role">
+      <span>Feeders:</span>
+      <div class="role-controls">
+        <button class="staff-button" onclick="unassignStaff('feeder')" aria-label="Remove feeder">&#x2212;</button>
+        <span id="staffFeeders">0</span>
+        <button class="staff-button" onclick="assignStaff('feeder')" aria-label="Add feeder">&#x2b;</button>
+      </div>
+    </div>
+    <div class="staff-role">
+      <span>Harvesters:</span>
+      <div class="role-controls">
+        <button class="staff-button" onclick="unassignStaff('harvester')" aria-label="Remove harvester">&#x2212;</button>
+        <span id="staffHarvesters">0</span>
+        <button class="staff-button" onclick="assignStaff('harvester')" aria-label="Add harvester">&#x2b;</button>
+      </div>
+    </div>
+    <div class="staff-role">
+      <span>Feed Managers:</span>
+      <div class="role-controls">
+        <button class="staff-button" onclick="unassignStaff('feedManager')" aria-label="Remove feed manager">&#x2212;</button>
+        <span id="staffManagers">0</span>
+        <button class="staff-button" onclick="assignStaff('feedManager')" aria-label="Add feed manager">&#x2b;</button>
+      </div>
+    </div>
+  </div>
+
+  <main id="mainLayout">
     <section id="pensSection">
      
     <!-- Pen grid -->

--- a/style.css
+++ b/style.css
@@ -1417,6 +1417,80 @@ html.modal-open {
   color: var(--bg-darker);
 }
 
+/* Quick Status Bar */
+#quickStatusBar {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  padding: 8px 0;
+}
+
+.status-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--bg-button);
+  color: var(--text-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: pointer;
+  box-shadow: 0 0 4px var(--shadow-light);
+  transition: box-shadow 0.2s ease;
+}
+
+.status-icon img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  margin-bottom: 2px;
+}
+
+.status-label {
+  font-size: 12px;
+}
+
+.status-badge {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background: var(--accent);
+  color: var(--text-dark);
+  border-radius: 10px;
+  padding: 1px 4px;
+  font-size: 10px;
+}
+
+.status-badge.alert {
+  background: #e74c3c;
+  color: #fff;
+}
+
+.status-icon.active {
+  box-shadow: 0 0 8px var(--accent);
+}
+
+.status-panel {
+  max-width: 960px;
+  margin: 0 auto;
+  background: var(--bg-panel);
+  padding: 16px;
+  border-radius: 10px;
+  box-shadow: 0 0 8px var(--shadow-medium);
+  margin-top: 10px;
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+}
+
+.status-panel.visible {
+  max-height: 1000px;
+  opacity: 1;
+}
+
 
 /* Mobile sidebar behavior */
 @media (max-width: 700px) {

--- a/ui.js
+++ b/ui.js
@@ -215,6 +215,21 @@ function updateDisplay(){
   if(totalFeedEl) totalFeedEl.innerText = totalFeed.toFixed(1);
   const totalFeedCapEl = document.getElementById('totalFeedCapacity');
   if(totalFeedCapEl) totalFeedCapEl.innerText = totalFeedCap;
+  const feedBadge = document.getElementById('feedStatusBadge');
+  if(feedBadge) feedBadge.textContent = `${totalFeed.toFixed(0)}/${totalFeedCap}kg`;
+  const bargeBadge = document.getElementById('bargeStatusBadge');
+  if(bargeBadge) bargeBadge.textContent = `${site.pens.filter(p=>p.feeder && p.bargeIndex===state.currentBargeIndex).length}/${barge.feederLimit}`;
+  const staffBadge = document.getElementById('staffStatusBadge');
+  const unassigned = site.staff.filter(s=>!s.role).length;
+  if(staffBadge){
+    if(unassigned>0){
+      staffBadge.textContent = `Idle:${unassigned}`;
+      staffBadge.classList.add('alert');
+    } else {
+      staffBadge.textContent = site.staff.length;
+      staffBadge.classList.remove('alert');
+    }
+  }
 
   // vessel grid
 
@@ -1640,6 +1655,27 @@ function populateSiteList(){
   });
 }
 
+function toggleStatusPanel(key){
+  const panels = { feed: 'feedPanel', barge: 'bargePanel', staff: 'staffPanel' };
+  const icons  = { feed: 'feedStatusIcon', barge: 'bargeStatusIcon', staff: 'staffStatusIcon' };
+  const panel = document.getElementById(panels[key]);
+  if(!panel) return;
+  const isVisible = panel.classList.contains('visible');
+  Object.values(panels).forEach(id=>{
+    const el = document.getElementById(id);
+    if(el) el.classList.remove('visible');
+  });
+  Object.values(icons).forEach(id=>{
+    const el = document.getElementById(id);
+    if(el) el.classList.remove('active');
+  });
+  if(!isVisible){
+    panel.classList.add('visible');
+    const icon = document.getElementById(icons[key]);
+    if(icon) icon.classList.add('active');
+  }
+}
+
 // --- PURCHASES & ACTIONS ---
 export {
   updateDisplay,
@@ -1700,5 +1736,6 @@ export {
   outsideBankActionHandler,
   selectSite,
   populateSiteList,
-  toggleLicenseList
+  toggleLicenseList,
+  toggleStatusPanel
 };


### PR DESCRIPTION
## Summary
- add a quick status bar with icons and badges for Feed, Barge and Staff
- show system panels under the bar and migrate existing UI there
- implement toggle behavior and update icon badges in the display cycle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688671d3c53483298ed04376cf3bbc02