### PR TITLE
Consolidate shipyard notices on load

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -949,6 +949,8 @@ function simulateFeedManagers(){
 // Run simplified game ticks to account for offline progress
 // Locked pens are ignored when calculating feed usage
 function simulateOfflineProgress(ms){
+  state.isSimulatingOffline = true;
+  state.shipyardRestockedDuringOffline = false;
   const totalSeconds = Math.floor(ms / 1000);
   const daySeconds = state.DAY_DURATION_MS / 1000;
   let feedUsed = 0;
@@ -1004,8 +1006,8 @@ function simulateOfflineProgress(ms){
 
   const daysPassed = Math.floor(totalSeconds / daySeconds);
   advanceDays(daysPassed);
-
-  return { daysPassed, feedUsed };
+  state.isSimulatingOffline = false;
+  return { daysPassed, feedUsed, shipyardRestocked: state.shipyardRestockedDuringOffline };
 }
 
 // --- GAME TIME LOOP ---

--- a/gameState.js
+++ b/gameState.js
@@ -59,6 +59,8 @@ const state = {
 
   statusMessage: '',
   lastOfflineInfo: null,
+  isSimulatingOffline: false,
+  shipyardRestockedDuringOffline: false,
   lastMarketUpdateString: 'Spring 1, Year 1',
   harvestsCompleted: 0,
   milestones: {},
@@ -358,7 +360,11 @@ function getLocationByName(n){
 function checkShipyardRestock(){
   if(state.totalDaysElapsed - state.shipyardLastRefreshDay >= state.SHIPYARD_RESTOCK_INTERVAL){
     generateShipyardInventory();
-    addStatusMessage('New used vessels have arrived at auction.');
+    if(state.isSimulatingOffline){
+      state.shipyardRestockedDuringOffline = true;
+    } else {
+      addStatusMessage('New used vessels have arrived at auction.');
+    }
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -29,6 +29,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const hrs = (state.lastOfflineInfo.elapsedMs/3600000).toFixed(1);
     ui.openModal(`Welcome back! ${hrs}h passed while you were away. `+
                  `${days} in-game days progressed and about ${feed}kg feed was used.`);
+    if(state.lastOfflineInfo.shipyardRestocked){
+      state.addStatusMessage(`${state.shipyardInventory.length} used vessels available at auction.`);
+    }
   }
   setInterval(actions.saveGame, state.AUTO_SAVE_INTERVAL_MS);
   setInterval(checkMilestones, 1000);


### PR DESCRIPTION
## Summary
- add state flags to suppress repeat shipyard messages
- record when the shipyard restocks during offline simulation
- display a single toast after loading with the total used vessels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68868c98f5748329b2f4bee4acce3166