### PR TITLE
Fix shipyard scroll containment

### DIFF
--- a/style.css
+++ b/style.css
@@ -238,7 +238,9 @@ button:active {
   left: 0;
   width: 100vw;
   height: 100vh;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
   box-sizing: border-box;
   background: var(--bg-darker);
   color: var(--text-light);
@@ -316,6 +318,10 @@ html.modal-open {
 #customBuildPanel {
   flex: 1;
   min-width: 0;
+}
+
+#usedVesselsPanel {
+  overflow-y: auto;
 }
 
 #shipyardToggleButtons {


### PR DESCRIPTION
## Summary
- keep shipyard modal scroll inside the overlay
- allow used vessel list to scroll independently

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886d22cad548329b2bd1b2f74b308eb