### PR TITLE
Onboarding soft gates via milestones

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -21,7 +21,7 @@ import {
 } from "./data.js";
 import { Site, Barge, Pen, Vessel } from "./models.js";
 import state, { getTimeState, addStatusMessage, advanceDays, setupMarketData, updateMarketPrices } from "./gameState.js";
-import { initMilestones } from './milestones.js';
+import { initMilestones, checkMilestones } from './milestones.js';
 import { initContracts, openContractDeliveryModal, closeContractDeliveryModal, deliverContract, checkVesselContractEligibility } from './contracts.js';
 
 const OFFLINE_STEP_SECONDS = 60; // simulation granularity for offline progress
@@ -749,6 +749,8 @@ function restockPen(sp, qty){
   sanitizePen(pen);
   updateDisplay();
   closeRestockModal();
+  state.milestones.firstStock = true;
+  checkMilestones();
 }
 // dev menu
 function addDevCash() {

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
           <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" onclick="toggleMobileActions()" />
           <div id="mobileActionGroup" class="hidden">
             <button onclick="openMarketReport()">Market</button>
-            <button onclick="openShipyard()">Shipyard</button>
+            <button id="shipyardBtn" onclick="openShipyard()">Shipyard</button><span id="shipyardLockReason" class="lock-reason"></span>
             <button onclick="openLogbook()" title="Open Logbook">Logbook</button>
             <button onclick="toggleDevTools()">⚙️</button>
           </div>
@@ -158,8 +158,9 @@
       <div id="newPenControls" class="newPenControls">
         <label for="newPenBargeSelect">Add Pen to Barge:</label>
         <select id="newPenBargeSelect" onchange="updateSelectedBargeDisplay()"></select>
-        <button onclick="buyNewPen(document.getElementById('newPenBargeSelect').value)">+ Pen</button>
+        <button id="buyPenBtn" onclick="buyNewPen(document.getElementById('newPenBargeSelect').value)">+ Pen</button>
         <span id="selectedBargeDisplay"></span>
+        <div id="penLockReason" class="lock-reason"></div>
       </div>
         <div id="penGridContainer" class="grid">
         </div>

--- a/milestones.js
+++ b/milestones.js
@@ -4,6 +4,18 @@ import { openModal } from './ui.js';
 // List of milestone definitions
 const milestones = [
   {
+    id: 'firstStock',
+    description: 'Stock your first pen.',
+    check: () => state.milestones.firstStock === true,
+    reward: () => {}
+  },
+  {
+    id: 'firstSale',
+    description: 'Complete your first sale.',
+    check: () => state.milestones.firstSale === true,
+    reward: () => {}
+  },
+  {
     id: 'firstHarvest',
     description: 'Harvest any pen for the first time.',
     check: () => state.harvestsCompleted > 0,

--- a/style.css
+++ b/style.css
@@ -1840,3 +1840,9 @@ html.modal-open {
   font-style: italic;
   color: var(--text-muted);
 }
+
+.lock-reason {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-left: 0.5rem;
+}

--- a/ui.js
+++ b/ui.js
@@ -22,7 +22,7 @@ import state, {
   getSiteHarvestRate,
 } from "./gameState.js";
 import { renderContracts } from "./contracts.js";
-import { milestones } from './milestones.js';
+import { milestones, checkMilestones } from './milestones.js';
 import { depositToBank, withdrawFromBank, takeLoan, repayLoan } from "./bank.js";
 
 const speciesColors = {
@@ -189,6 +189,22 @@ function updateDisplay(){
       playBtn.style.display = 'none';
       pauseBtn.style.display = 'inline';
     }
+  }
+
+  // milestone-gated actions
+  const shipyardBtn = document.getElementById('shipyardBtn');
+  const shipyardReason = document.getElementById('shipyardLockReason');
+  const shipyardUnlocked = state.milestones.firstStock;
+  if(shipyardBtn){
+    shipyardBtn.disabled = !shipyardUnlocked;
+    if(shipyardReason) shipyardReason.textContent = shipyardUnlocked ? '' : 'Unlocks after stocking your first pen.';
+  }
+  const penBtn = document.getElementById('buyPenBtn');
+  const penReason = document.getElementById('penLockReason');
+  const penUnlocked = state.milestones.firstHarvest && state.milestones.firstSale;
+  if(penBtn){
+    penBtn.disabled = !penUnlocked;
+    if(penReason) penReason.textContent = penUnlocked ? '' : 'Unlocks after your first harvest & sale.';
   }
 
   // barge card & feed overview
@@ -1364,6 +1380,10 @@ function finishOffloading(vessel, market, canceled=false){
   vessel.actionEndsAt = 0;
   let earned = vessel.offloadRevenue || 0;
   state.cash += earned;
+  if(earned > 0){
+    state.milestones.firstSale = true;
+    checkMilestones();
+  }
   vessel.offloadRevenue = 0;
   vessel.offloadMarket = null;
   const hIdx = vessel.offloadHoldIndex ?? 0;


### PR DESCRIPTION
## Summary
- Track early progression with new `firstStock` and `firstSale` milestones and default them during init
- Flip milestone flags when restocking pens or completing profitable offloads
- Disable Shipyard and new pen purchases until respective milestones with UI reasons

## Testing
- `npm test`

## Manual Test Plan
- Start a new game: Shipyard and + Pen buttons are disabled with unlock reasons
- Restock a pen: Shipyard button unlocks
- Harvest then sell: + Pen button unlocks
- Save and reload: unlocked actions remain available

------
https://chatgpt.com/codex/tasks/task_e_6896f191ab008329ba4fd701d8d4ced0