### PR TITLE
Onboarding polish: unlock highlight + one-shot tips

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1123,6 +1123,7 @@ function saveGame() {
     unlockedContractTiers: state.unlockedContractTiers,
     milestones: state.milestones,
     bank: state.bank,
+    tips: state.tips,
     marketStates: markets.map(m => ({
       name: m.name,
       prices: m.prices,
@@ -1165,6 +1166,7 @@ function loadGame() {
       state.contractsCompletedByTier = obj.contractsCompletedByTier ?? {};
       state.unlockedContractTiers = obj.unlockedContractTiers ?? [0];
       state.milestones = obj.milestones ?? {};
+      state.tips = Object.assign({ vesselUnlocked:false, penUnlocked:false }, obj.tips);
       if(obj.bank){
         state.bank.deposit = obj.bank.deposit ?? state.bank.deposit;
         state.bank.depositInterestRate = obj.bank.depositInterestRate ?? state.bank.depositInterestRate;

--- a/gameState.js
+++ b/gameState.js
@@ -69,6 +69,10 @@ const state = {
   milestones: {},
   contractsCompletedByTier: {},
   unlockedContractTiers: [0],
+  tips: {
+    vesselUnlocked: false,
+    penUnlocked: false,
+  },
 
   // --- Banking System ---
   bank: {

--- a/style.css
+++ b/style.css
@@ -1845,4 +1845,31 @@ html.modal-open {
   color: var(--text-muted);
   font-size: 0.9rem;
   margin-left: 0.5rem;
+  max-width: 160px;
+  display: inline-block;
+  vertical-align: middle;
+  word-wrap: break-word;
+}
+
+@media (max-width: 480px) {
+  .lock-reason {
+    font-size: 0.75rem;
+    max-width: 120px;
+  }
+}
+
+@keyframes pulse-once {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 215, 0, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 215, 0, 0);
+  }
+}
+
+.pulse-once {
+  animation: pulse-once 1.5s ease-out;
 }

--- a/ui.js
+++ b/ui.js
@@ -66,6 +66,12 @@ document.addEventListener('click', evt => {
   }
 });
 
+function pulseOnce(el){
+  if(!el) return;
+  el.classList.add('pulse-once');
+  setTimeout(()=>el.classList.remove('pulse-once'), 1500);
+}
+
 function toggleMobileActions(){
   const group = document.getElementById('mobileActionGroup');
   const toggle = document.getElementById('mobileActionToggle');
@@ -198,6 +204,11 @@ function updateDisplay(){
   if(shipyardBtn){
     shipyardBtn.disabled = !shipyardUnlocked;
     if(shipyardReason) shipyardReason.textContent = shipyardUnlocked ? '' : 'Unlocks after stocking your first pen.';
+    if(shipyardUnlocked && !state.tips.vesselUnlocked){
+      pulseOnce(shipyardBtn);
+      openModal('Now you can buy another vessel to speed up harvesting.');
+      state.tips.vesselUnlocked = true;
+    }
   }
   const penBtn = document.getElementById('buyPenBtn');
   const penReason = document.getElementById('penLockReason');
@@ -205,6 +216,11 @@ function updateDisplay(){
   if(penBtn){
     penBtn.disabled = !penUnlocked;
     if(penReason) penReason.textContent = penUnlocked ? '' : 'Unlocks after your first harvest & sale.';
+    if(penUnlocked && !state.tips.penUnlocked){
+      pulseOnce(penBtn);
+      openModal('Now you can buy another pen to expand your farm.');
+      state.tips.penUnlocked = true;
+    }
   }
 
   // barge card & feed overview


### PR DESCRIPTION
## Summary
- Pulse newly unlocked shipyard and pen purchase buttons to draw attention
- Show one-shot tips explaining vessel and pen unlocks, persisting their flags
- Harden `.lock-reason` styling for responsive layouts

## Testing
- `npm test`

## Manual Test Plan
- New game → buttons gated with reasons
- Restock → “Buy New Vessel” pulses once; tip shows once; persists as shown after reload
- Harvest then sell → “Buy New Pen” pulses once; tip shows once; persists
- On mobile width, `.lock-reason` doesn’t overflow or resize buttons


------
https://chatgpt.com/codex/tasks/task_e_68976a19039c8329ad878709b20c0dfb