### PR TITLE
fix: restore missing globals for contract modals

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1374,9 +1374,6 @@ const actions = {
   outsideBankActionHandler,
   selectSite,
   populateSiteList,
-  openContractDeliveryModal,
-  closeContractDeliveryModal,
-  deliverContract,
   logVesselHolds,
 };
 

--- a/contracts.js
+++ b/contracts.js
@@ -1,5 +1,4 @@
-// Global state reference
-const state = window.state;
+// Global contracts list uses shared game state
 let contracts = [];
 
 // Capitalize helper replicated here to keep module independent
@@ -342,4 +341,18 @@ function renderContracts(){
     row.appendChild(info);
     container.appendChild(row);
   });
+}
+
+// expose contract helpers globally for existing event handlers
+const contractAPI = {
+  initContracts,
+  renderContracts,
+  openContractDeliveryModal,
+  closeContractDeliveryModal,
+  deliverContract,
+  checkVesselContractEligibility,
+};
+
+for (const key in contractAPI) {
+  window[key] = (...args) => window.bootGuard(() => contractAPI[key](...args));
 }

--- a/index.html
+++ b/index.html
@@ -449,13 +449,13 @@
     <div id="onboardingChecklist" class="onboarding-card hidden"></div>
     <div id="toastContainer"></div>
     <script src="data.js" defer></script>
+    <script src="models.js" defer></script>
     <script src="gameState.js" defer></script>
-    <script src="ui.js" defer></script>
     <script src="actions.js" defer></script>
+    <script src="ui.js" defer></script>
     <script src="bank.js" defer></script>
     <script src="contracts.js" defer></script>
     <script src="milestones.js" defer></script>
-    <script src="models.js" defer></script>
   <script data-goatcounter="https://rwzephyr.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load model classes before game state and actions before UI so Site and onBoot exist
- expose contract modal helpers globally and drop duplicate state declaration
- stop referencing contract helpers from actions module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b198835083298cb965d9f18bbc2d