### PR TITLE
Fix runtime JS errors (modals/boot) and restore core loop

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -366,31 +366,10 @@ function closeMoveModal(){
   document.getElementById('moveModal').classList.remove('visible');
 }
 
-function openBargeUpgradeModal(){
-  uiOpenBargeUpgradeModal();
-}
-function closeBargeUpgradeModal(){
-  uiCloseBargeUpgradeModal();
-}
-
-function openShipyard(){
-  uiOpenShipyard();
-}
-function closeShipyard(){
-  uiCloseShipyard();
-}
-function openSiteManagement(){
-  uiOpenSiteManagement();
-}
-function closeSiteManagement(){
-  uiCloseSiteManagement();
-}
-function openDevModal(){ uiOpenDevModal(); }
-function closeDevModal(){ uiCloseDevModal(); }
 function toggleDevTools(){
   const modal = document.getElementById('devModal');
-  if(modal.classList.contains('visible')) uiCloseDevModal();
-  else uiOpenDevModal();
+  if(modal.classList.contains('visible')) closeDevModal();
+  else openDevModal();
 }
 
 function toggleOnboarding(){
@@ -402,15 +381,6 @@ function toggleOnboarding(){
   }
   updateDisplay();
   saveGame();
-}
-function openCustomBuild(){
-  uiOpenCustomBuild();
-}
-function backToShipyardList(){
-  uiBackToShipyardList();
-}
-function updateCustomBuildStats(){
-  uiUpdateCustomBuildStats();
 }
 
 function refreshShipyardListings(){
@@ -1300,12 +1270,6 @@ const actions = {
   devSetMarketModifierPrompt,
   devInstantSellAll,
   togglePanel,
-  openModal,
-  closeModal,
-  openRestockModal,
-  closeRestockModal,
-  closeHarvestModal,
-  confirmHarvest,
   harvestPen,
   cancelVesselHarvest,
   feedFishPen,
@@ -1313,11 +1277,6 @@ const actions = {
   restockPenUI,
   upgradeFeeder,
   assignBarge,
-  openSellModal,
-  closeSellModal,
-  sellCargo,
-  startOffloading,
-  finishOffloading,
   saveGame,
   loadGame,
   resetGame,
@@ -1337,43 +1296,13 @@ const actions = {
   moveVesselTo,
   showTab,
   updateSelectedBargeDisplay,
-  openBargeUpgradeModal,
-  closeBargeUpgradeModal,
-  openShipyard,
-  closeShipyard,
-  openCustomBuild,
-  backToShipyardList,
-  updateCustomBuildStats,
   refreshShipyardListings,
   buyShipyardVessel,
   confirmCustomBuild,
-  openMarketReport,
-  closeMarketReport,
-  openBank,
-  closeBank,
-  openMarketReports,
-  switchLogbookSection,
-  openLogbook,
-  closeLogbook,
-  openSiteManagement,
-  closeSiteManagement,
-  openDevModal,
-  closeDevModal,
   toggleDevTools,
   toggleOnboarding,
   pauseTime,
   resumeTime,
-  updateFeedPurchaseUI,
-  syncFeedPurchase,
-  confirmBuyFeed,
-  setFeedPurchaseMax,
-  toggleSiteList,
-  toggleMobileActions,
-  toggleSiteActions,
-  toggleBankActions,
-  outsideBankActionHandler,
-  selectSite,
-  populateSiteList,
   logVesselHolds,
 };
 


### PR DESCRIPTION
## Summary
- Trim actions.js to stop referencing UI helpers before they're defined
- Use UI's global functions for modals and shipyard features
- Route dev tool toggling through global open/close handlers

## Testing
- `node --check actions.js`
- `node --check ui.js`
- `node --check contracts.js`
- `npm test`

## Acceptance Tests (manual)
1. Hard reload with DevTools → Console shows 0 errors.
2. Fresh storage (clear site data) → a site appears; onboarding checklist shows.
3. Feed once; biomass increases without errors.
4. Open harvest from a vessel’s cog → modal appears; request > capacity clamps; ETA never negative; start harvest locks the pen UI.
5. Sell after offload → sell modal opens; sale succeeds; cash increases; buy-pen unlocks; no NaN displays.
6. Reload → unlocks persist; tooltips don’t re-flash unless reset.


------
https://chatgpt.com/codex/tasks/task_e_6897bf113d688329b37456b5b638fe7a