### PR TITLE
Ensure contract and milestone modules load before actions

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1339,10 +1339,24 @@ for (const key in actions){
   window[key] = (...args) => window.bootGuard(()=>actions[key](...args));
 }
 
+function safeInit(name){
+  if (typeof window[name] === 'function'){
+    window[name]();
+  } else {
+    const id = setInterval(()=>{
+      const fn = window[name];
+      if (typeof fn === 'function'){
+        clearInterval(id);
+        fn();
+      }
+    }, 50);
+  }
+}
+
 onBoot(()=>{
   loadGame();
-  initContracts();
-  initMilestones();
+  safeInit('initContracts');
+  safeInit('initMilestones');
   setInterval(saveGame, state.AUTO_SAVE_INTERVAL_MS);
   setInterval(checkMilestones, 1000);
   setInterval(autoFeedTick, 1000);

--- a/index.html
+++ b/index.html
@@ -460,11 +460,11 @@
     <script src="data.js" defer></script>
     <script src="models.js" defer></script>
     <script src="gameState.js" defer></script>
+    <script src="contracts.js" defer></script>
+    <script src="milestones.js" defer></script>
     <script src="actions.js" defer></script>
     <script src="ui.js" defer></script>
     <script src="bank.js" defer></script>
-    <script src="contracts.js" defer></script>
-    <script src="milestones.js" defer></script>
   <script data-goatcounter="https://rwzephyr.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Load `contracts.js` and `milestones.js` ahead of `actions.js` in `index.html`
- Guard initialization of contracts and milestones modules in `actions.js`

## Testing
- `npm test`
- `node - <<'NODE'
const {JSDOM} = require('jsdom');
JSDOM.fromFile('index.html', {
  runScripts: 'dangerously',
  resources: 'usable',
  pretendToBeVisual: true,
  beforeParse(window){
    const timers = [];
    const origSetInterval = window.setInterval.bind(window);
    window.setInterval = function(fn, ms){
      console.log('setInterval called', fn.name || 'anonymous', ms);
      const id = origSetInterval(fn, ms);
      timers.push(id);
      return id;
    };
    window.__timers = timers;
    window.console.error = (...args)=>{ console.log('console.error', ...args); };
  }
}).then(dom=>{
  dom.window.addEventListener('load', ()=>{
    console.log('loaded');
    setTimeout(()=>{
      dom.window.__timers.forEach(id => dom.window.clearInterval(id));
      console.log('done');
    }, 100);
  });
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689819ca0b3083299ede4af7af6931c2