### PR TITLE
Call updateDisplay during game time tick

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1069,6 +1069,7 @@ function simulateOfflineProgress(ms){
 function gameTimeTick(){
   if(!state.timePaused){
     state.advanceDay();
+    updateDisplay();
   }
 }
 


### PR DESCRIPTION
## Summary
- Refresh the UI each day by calling `updateDisplay` after advancing time.

## Testing
- `npm test`
- Node script simulating a day tick updates the displayed date

------
https://chatgpt.com/codex/tasks/task_e_6898243194e483299a2b5ec9cc80506c