### PR TITLE
Refactor vessel cards into responsive sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
 
   <main id="mainLayout">
     <section id="pensSection">
-     
+
     <!-- Pen grid -->
     <div id="penGrid">
       <h2>Pen Status</h2>
@@ -180,12 +180,11 @@
       </template>
     </div>
     </section>
-  </main>
-
-  <footer id="bottomSection">
-    <div class="container">
-      <div id="vesselGridContainer" class="vesselGrid">
-      </div>
+    <section id="vesselsSection">
+      <div id="vesselGrid">
+        <h2>Vessel Status</h2>
+        <div id="vesselGridContainer" class="vesselGrid">
+        </div>
         <template id="vesselCardTemplate">
           <div class="vesselCard compact">
             <div class="vessel-header">
@@ -212,8 +211,9 @@
             </div>
           </div>
         </template>
-    </div>
-  </footer>
+      </div>
+    </section>
+  </main>
 
   <!-- Modals -->
     <div id="modal">

--- a/style.css
+++ b/style.css
@@ -945,12 +945,12 @@ html.modal-open {
 .vesselCard {
   background: var(--bg-panel);
   border-radius: 10px;
+  width: 180px;
+  flex: 0 0 auto;
   padding: 12px;
   margin: 0 0 16px;
   color: var(--text-light);
   box-shadow: 0 0 4px var(--shadow-light);
-  max-width: 90vw;
-  flex: 1 1 200px;
   transition: transform 0.2s, box-shadow 0.2s;
   position: relative;
 }
@@ -1586,28 +1586,18 @@ html.modal-open {
   flex: 2;
 }
 
-#rightSidebar {
+#vesselsSection {
   flex: 1;
   min-width: 260px;
   display: flex;
   flex-direction: column;
 }
 
-
-/* Footer vessel section */
-#bottomSection {
-  margin-top: 20px;
-}
-
-#bottomSection .vesselCard {
-  margin: 0;
-}
-
 .vesselGrid {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 16px;
-  justify-content: center;
+  align-items: flex-start;
   padding: 10px 0;
 }
 
@@ -1829,10 +1819,13 @@ html.modal-open {
   #mainLayout {
     flex-direction: column;
   }
-  #rightSidebar {
+  #vesselsSection {
     min-width: unset;
     width: 100%;
     flex-direction: column;
+  }
+  #vesselsSection .vesselGrid {
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- Move vessel grid from footer into main layout alongside pens
- Introduce responsive sidebar layout and narrow vessel card width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983bc02374832998ff0702b97522d7