### PR TITLE
Add vessel status badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,6 @@
         <template id="vesselCardTemplate">
           <div class="vesselCard compact">
             <div class="vessel-header">
-              <div class="vessel-icon"></div>
               <h3 class="vessel-name"><span class="name-text"></span><span class="rename-icon" title="Rename">&#9998;</span></h3>
               <button class="actions-toggle" title="Actions">⚙</button>
               <div class="action-menu hidden">

--- a/style.css
+++ b/style.css
@@ -856,6 +856,25 @@ html.modal-open {
   object-fit: contain;
 }
 
+.vessel-badge {
+  width: 40px;
+  height: 40px;
+  position: absolute;
+  top: -12px;
+  right: -12px;
+  z-index: 10;
+  border-radius: 50%;
+  border: 2px solid white;
+  overflow: hidden;
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.vessel-badge img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .penCard:hover,
 .vesselCard:hover,
 .bargeCard:hover,
@@ -991,10 +1010,22 @@ html.modal-open {
   top: auto;
   bottom: 100%;
 }
-.status-harvesting { border-left: 6px solid #2ecc71; }
-.status-idle { border-left: 6px solid #3498db; }
-.status-delivering { border-left: 6px solid #e67e22; }
-.status-docked { border-left: 6px solid #7f8c8d; }
+.status-harvesting,
+.status-idle,
+.status-delivering,
+.status-docked {
+  border-left: none;
+}
+
+.status-idle .vessel-badge,
+.status-docked .vessel-badge {
+  background-color: #2ecc71;
+}
+
+.status-harvesting .vessel-badge,
+.status-delivering .vessel-badge {
+  background-color: #e67e22;
+}
 .vesselCard.placeholder { opacity: 0.6; }
 .staffCard {
   background: var(--bg-panel);
@@ -1735,12 +1766,6 @@ html.modal-open {
 }
 
 .species-icon {
-  width: 48px;
-  height: 48px;
-  object-fit: contain;
-}
-
-.vessel-icon {
   width: 48px;
   height: 48px;
   object-fit: contain;

--- a/ui.js
+++ b/ui.js
@@ -631,15 +631,16 @@ function renderVesselGrid(){
   state.vessels.forEach((vessel, idx)=>{
     const clone = tmpl.content.cloneNode(true);
     const card = clone.querySelector('.vesselCard');
-    const iconCont = clone.querySelector('.vessel-icon');
     const iconPath = vesselIcons[vessel.class];
-    if(iconCont){
-      if(iconPath){
-        iconCont.innerHTML = `<img src="${iconPath}" class="vessel-icon" alt="${vessel.class}">`;
-      } else {
-        iconCont.textContent = '🛥️';
-      }
+    const badge = document.createElement('div');
+    badge.classList.add('vessel-badge');
+    if(iconPath){
+      const icon = document.createElement('img');
+      icon.src = iconPath;
+      icon.alt = vessel.class;
+      badge.appendChild(icon);
     }
+    card.appendChild(badge);
     card.querySelector('.vessel-name .name-text').textContent = vessel.name;
     card.querySelector('.rename-icon').onclick = ()=>{ state.currentVesselIndex = idx; renameVessel(); };
     card.querySelector('.vessel-tier').textContent = vesselTiers[vessel.tier].name;
@@ -649,7 +650,7 @@ function renderVesselGrid(){
     let status = 'Idle';
     if(vessel.status === 'harvesting'){ status='Harvesting'; statusClass='status-harvesting'; }
     else if(vessel.status === 'offloading' || vessel.status === 'selling'){ status='Delivering'; statusClass='status-delivering'; }
-    else if(vessel.status === 'enRoute'){ status='Traveling'; }
+    else if(vessel.status === 'enRoute'){ status='Traveling'; statusClass='status-delivering'; }
     else if(vessel.location === 'Dock'){ status='Docked'; statusClass='status-docked'; }
     if(vessel.busyUntil && vessel.busyUntil > Date.now()){
       const eta = Math.max(0, (vessel.busyUntil - Date.now())/1000);
@@ -715,14 +716,19 @@ function updateVesselCards(){
   state.vessels.forEach((vessel, idx)=>{
     const card = grid.children[idx];
     if(!card) return;
-    const iconCont = card.querySelector('.vessel-icon');
     const iconPath = vesselIcons[vessel.class];
-    if(iconCont){
-      if(iconPath){
-        iconCont.innerHTML = `<img src="${iconPath}" class="vessel-icon" alt="${vessel.class}">`;
-      } else {
-        iconCont.textContent = '🛥️';
-      }
+    let badge = card.querySelector('.vessel-badge');
+    if(!badge){
+      badge = document.createElement('div');
+      badge.classList.add('vessel-badge');
+      card.appendChild(badge);
+    }
+    badge.innerHTML = '';
+    if(iconPath){
+      const icon = document.createElement('img');
+      icon.src = iconPath;
+      icon.alt = vessel.class;
+      badge.appendChild(icon);
     }
     card.querySelector('.vessel-name .name-text').textContent = vessel.name;
     card.querySelector('.vessel-tier').textContent = vesselTiers[vessel.tier].name;
@@ -732,7 +738,7 @@ function updateVesselCards(){
     let status = 'Idle';
     if(vessel.status === 'harvesting'){ status='Harvesting'; statusClass='status-harvesting'; }
     else if(vessel.status === 'offloading' || vessel.status === 'selling'){ status='Delivering'; statusClass='status-delivering'; }
-    else if(vessel.status === 'enRoute'){ status='Traveling'; }
+    else if(vessel.status === 'enRoute'){ status='Traveling'; statusClass='status-delivering'; }
     else if(vessel.location === 'Dock'){ status='Docked'; statusClass='status-docked'; }
     if(vessel.busyUntil && vessel.busyUntil > Date.now()){
       const eta = Math.max(0, (vessel.busyUntil - Date.now())/1000);


### PR DESCRIPTION
## Summary
- Add vessel badge overlay with vessel icon
- Color vessel badge based on idle or busy state, replacing border status
- Treat en-route vessels as busy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898bca12acc83298361b167876bdcab