### PR TITLE
Add skip-save flag and improve restart logic

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -755,7 +755,13 @@ function devAddBiomass(amount = 10){
 
 function devRestartGame() {
   if (confirm("Restart the game?")) {
-    localStorage.clear();
+    state.skipSave = true;
+    window.removeEventListener('beforeunload', saveGame);
+    window.removeEventListener('pagehide', saveGame);
+    if (state.autoSaveIntervalId) {
+      clearInterval(state.autoSaveIntervalId);
+    }
+    localStorage.removeItem(state.SAVE_KEY);
     location.reload();
   }
 }
@@ -1074,6 +1080,7 @@ function gameTimeTick(){
 
 // --- SAVE SYSTEM ---
 function saveGame() {
+  if (state.skipSave) return;
   const data = {
     cash: state.cash,
     penPurchaseCost: state.penPurchaseCost,
@@ -1353,13 +1360,13 @@ function safeInit(name){
   }
 }
 
-onBoot(()=>{
-  loadGame();
-  safeInit('initContracts');
-  safeInit('initMilestones');
-  setInterval(saveGame, state.AUTO_SAVE_INTERVAL_MS);
-  setInterval(checkMilestones, 1000);
-  setInterval(autoFeedTick, 1000);
-  setInterval(checkFeedManagers, 5000);
-  setInterval(gameTimeTick, state.DAY_DURATION_MS);
-});
+  onBoot(()=>{
+    loadGame();
+    safeInit('initContracts');
+    safeInit('initMilestones');
+    state.autoSaveIntervalId = setInterval(saveGame, state.AUTO_SAVE_INTERVAL_MS);
+    setInterval(checkMilestones, 1000);
+    setInterval(autoFeedTick, 1000);
+    setInterval(checkFeedManagers, 5000);
+    setInterval(gameTimeTick, state.DAY_DURATION_MS);
+  });

--- a/gameState.js
+++ b/gameState.js
@@ -15,6 +15,8 @@ const state = {
   FEED_THRESHOLD_PERCENT: 0.2,
   AUTO_SAVE_INTERVAL_MS: 30000, // 30 seconds
   SAVE_KEY: 'aquacultureEmpireSave',
+  skipSave: false,
+  autoSaveIntervalId: null,
   TRAVEL_TIME_FACTOR: 1000, // ms per distance unit
   OFFLOAD_RATE: 10, // kg per second
 


### PR DESCRIPTION
## Summary
- Add `skipSave` flag to bypass saving and track auto-save interval ID in state
- Preserve targeted save removal and restart without persisting old data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898be6fab2c83299ff502f1097b8967