### PR TITLE
fix: guard pen growth on empty pens

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -146,9 +146,11 @@ state.setupMarketData = setupMarketData;
 state.updateMarketPrices = updateMarketPrices;
 
 function applyGrowth(pen, species, feedKg){
-  const baseGain = feedKg / speciesData[species].fcr;
+  const data = speciesData[species];
+  if(!data || pen.fishCount === 0) return pen.averageWeight;
+  const baseGain = feedKg / data.fcr;
   let gain = baseGain;
-  const max = speciesData[species].maxWeight;
+  const max = data.maxWeight;
   if(max && pen.averageWeight > max){
     const excess = pen.averageWeight - max;
     const scale = Math.max(0.1, 1 - (excess / max));
@@ -189,6 +191,7 @@ function advanceDay() {
   state.sites.forEach(site => {
     site.pens.forEach(pen => {
       if(pen.locked) return;
+      if(!pen.species || pen.fishCount === 0) return;
       const newAvg = applyGrowth(pen, pen.species, 0);
       pen.averageWeight = newAvg;
     });


### PR DESCRIPTION
## Summary
- skip pens without fish or species during daily growth
- harden `applyGrowth` to handle missing species data and empty pens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c7de9adc8329abda3f403c7cac30