### PR TITLE
fix: show vessel icons on badges

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -293,6 +293,7 @@ function buyNewVessel(){
   state.cash -= NEW_VESSEL_COST;
     state.vessels.push(new Vessel({
       name: `Vessel ${state.vessels.length + 1}`,
+      class: 'skiff',
       maxBiomassCapacity: vesselTiers[0].maxBiomassCapacity, // TODO: remove after holds migration
       currentBiomassLoad: 0, // TODO: remove after holds migration
       cargoSpecies: null, // TODO: remove after holds migration
@@ -398,6 +399,7 @@ function buyShipyardVessel(idx){
   state.cash -= item.cost;
     const vessel = new Vessel({
       name: item.name,
+      class: item.class,
       maxBiomassCapacity: item.cargoCapacity, // TODO: remove after holds migration
       currentBiomassLoad: 0, // TODO: remove after holds migration
       cargoSpecies: null, // TODO: remove after holds migration
@@ -442,6 +444,7 @@ function confirmCustomBuild(){
   state.cash -= cost;
     const vessel = new Vessel({
       name: name,
+      class: cls,
       maxBiomassCapacity: base.baseCapacity, // TODO: remove after holds migration
       currentBiomassLoad: 0, // TODO: remove after holds migration
       cargoSpecies: null, // TODO: remove after holds migration
@@ -1154,6 +1157,7 @@ function loadGame() {
       state.vessels = obj.vessels ?? state.vessels;
       state.vessels.forEach(v => {
         if(!v.cargo) v.cargo = {};
+        if(!v.class) v.class = 'skiff';
           if(v.cargoSpecies === undefined) v.cargoSpecies = Object.keys(v.cargo)[0] || null; // TODO: remove after holds migration
         if(v.status === undefined){
           if(v.isHarvesting) v.status = 'harvesting';

--- a/gameState.js
+++ b/gameState.js
@@ -297,6 +297,7 @@ state.sites = [
 state.vessels = [
     new Vessel({
       name: 'Hauler 1',
+      class: 'skiff',
       maxBiomassCapacity: vesselTiers[0].maxBiomassCapacity, // TODO: remove after holds migration
       currentBiomassLoad: 0, // TODO: remove after holds migration
       cargoSpecies: null, // TODO: remove after holds migration

--- a/models.js
+++ b/models.js
@@ -68,6 +68,7 @@ class Site {
 class Vessel {
   constructor({
     name,
+    class: vesselClass = 'skiff',
       maxBiomassCapacity = 1000, // TODO: remove after holds migration
       currentBiomassLoad = 0, // TODO: remove after holds migration
       cargo = {},
@@ -86,6 +87,7 @@ class Vessel {
     actionEndsAt = 0
   } = {}) {
     this.name = name;
+    this.class = vesselClass;
       this.maxBiomassCapacity = maxBiomassCapacity; // TODO: remove after holds migration
       this.currentBiomassLoad = currentBiomassLoad; // TODO: remove after holds migration
     // Deprecated: cargo is maintained for legacy saves but no longer used


### PR DESCRIPTION
## Summary
- track vessel class and default to `skiff`
- include class when creating or loading vessels so badge icons render

## Testing
- `npm test`
- Manual: open the game and verify vessel card badges display the correct class icon

------
https://chatgpt.com/codex/tasks/task_e_6898f79739b08329808fdf6311bfa30a