### PR TITLE
Vessel cards: replace cog with ⋮ ellipsis (no behavior change)

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,14 +190,14 @@
             <div class="vessel-badge"></div>
             <div class="vessel-header">
               <h3 class="vessel-name"><span class="name-text"></span><span class="rename-icon" title="Rename">&#9998;</span></h3>
-              <button class="actions-toggle" title="Actions">⚙</button>
-              <div class="action-menu hidden">
-                <button class="harvest-btn">Harvest</button>
-                <button class="move-btn">Move</button>
-                <button class="sell-btn">Sell</button>
-                <button class="upgrade-btn">Upgrade</button>
-                <button class="cancel-btn">Cancel</button>
-              </div>
+                <button class="actions-toggle" aria-label="More vessel actions" title="More vessel actions" aria-expanded="false">⋮</button>
+                <div class="action-menu hidden" role="menu">
+                  <button class="harvest-btn" role="menuitem">Harvest</button>
+                  <button class="move-btn" role="menuitem">Move</button>
+                  <button class="sell-btn" role="menuitem">Sell</button>
+                  <button class="upgrade-btn" role="menuitem">Upgrade</button>
+                  <button class="cancel-btn" role="menuitem">Cancel</button>
+                </div>
             </div>
             <div class="stat status-line">Status: <span class="vessel-status"></span></div>
             <div class="progressBar"><div class="progress vessel-progress"></div></div>

--- a/style.css
+++ b/style.css
@@ -1113,12 +1113,31 @@ html.modal-open {
   gap: 4px;
 }
 .actions-toggle {
-  background: none;
-  border: none;
-  color: var(--text-light);
-  cursor: pointer;
-  font-size: 16px;
-}
+    background: none;
+    border: none;
+    color: var(--text-light);
+    cursor: pointer;
+    font-size: 20px;
+    margin: 0;
+    padding: 0;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    line-height: 1;
+  }
+
+  .actions-toggle:hover,
+  .actions-toggle:focus {
+    background-color: var(--bg-button);
+    color: var(--accent);
+  }
+
+  .actions-toggle:active {
+    transform: scale(0.95);
+  }
 .action-menu {
   position: absolute;
   top: 28px;

--- a/ui.js
+++ b/ui.js
@@ -705,11 +705,15 @@ function renderVesselGrid(){
     const detailsToggle = card.querySelector('.details-toggle');
     const details = card.querySelector('.vessel-details');
     if(detailsToggle && details){ detailsToggle.onclick = ()=>{ details.classList.toggle('hidden'); }; }
-    const actionsToggle = card.querySelector('.actions-toggle');
-    const actionMenu = card.querySelector('.action-menu');
-    if(actionsToggle && actionMenu){
-      actionsToggle.onclick = (e)=>{ e.stopPropagation(); actionMenu.classList.toggle('hidden'); };
-    }
+      const actionsToggle = card.querySelector('.actions-toggle');
+      const actionMenu = card.querySelector('.action-menu');
+      if(actionsToggle && actionMenu){
+        actionsToggle.onclick = (e)=>{
+          e.stopPropagation();
+          const isHidden = actionMenu.classList.toggle('hidden');
+          actionsToggle.setAttribute('aria-expanded', String(!isHidden));
+        };
+      }
     grid.appendChild(clone);
   });
 }


### PR DESCRIPTION
## Summary
- Replace vessel card gear icon with a real button showing a vertical ellipsis trigger
- Add ARIA roles and expanded state for vessel action menu items
- Style ellipsis button for a 28px tap target with hover/focus feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38e73bb24832981c494e6538eaebf