### PR TITLE
feat: reorganize vessel card actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,20 +189,24 @@
           <div class="vesselCard compact">
             <div class="vessel-badge"></div>
             <div class="vessel-header">
-              <h3 class="vessel-name"><span class="name-text"></span><span class="rename-icon" title="Rename">&#9998;</span></h3>
-                <button class="actions-toggle" aria-label="More vessel actions" title="More vessel actions" aria-expanded="false">⋮</button>
-                <div class="action-menu hidden" role="menu">
-                  <button class="harvest-btn" role="menuitem">Harvest</button>
-                  <button class="move-btn" role="menuitem">Move</button>
-                  <button class="sell-btn" role="menuitem">Sell</button>
-                  <button class="upgrade-btn" role="menuitem">Upgrade</button>
-                  <button class="cancel-btn" role="menuitem">Cancel</button>
-                </div>
+              <h3 class="vessel-name"><span class="name-text"></span></h3>
+              <button class="actions-toggle" aria-label="More vessel actions" title="More vessel actions" role="button" aria-haspopup="menu" aria-controls="" aria-expanded="false">⋮</button>
+              <div class="action-menu hidden" role="menu">
+                <button class="rename-btn" role="menuitem">Rename</button>
+                <button class="upgrade-btn" role="menuitem">Upgrade</button>
+                <button class="sell-vessel-btn" role="menuitem">Sell Vessel</button>
+                <button class="details-btn" role="menuitem">Details</button>
+                <button class="cancel-btn" role="menuitem">Cancel</button>
+              </div>
             </div>
             <div class="stat status-line">Status: <span class="vessel-status"></span></div>
             <div class="progressBar"><div class="progress vessel-progress"></div></div>
             <div class="stat load-line"><span class="vessel-load"></span> / <span class="vessel-capacity"></span> kg (<span class="load-percent"></span>%)</div>
-            <div class="details-toggle">Details ⌄</div>
+            <div class="vessel-actions">
+              <button class="harvest-btn" id="btn-harvest" title="Harvest">Harvest</button>
+              <button class="move-btn" id="btn-move" title="Move">Move</button>
+              <button class="offload-btn" id="btn-offload" title="Offload">Offload</button>
+            </div>
             <div class="vessel-details hidden">
               <div class="stat">Tier: <span class="vessel-tier"></span></div>
               <div class="stat">Location: <span class="vessel-location"></span></div>

--- a/style.css
+++ b/style.css
@@ -1113,31 +1113,31 @@ html.modal-open {
   gap: 4px;
 }
 .actions-toggle {
-    background: none;
-    border: none;
-    color: var(--text-light);
-    cursor: pointer;
-    font-size: 20px;
-    margin: 0;
-    padding: 0;
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    line-height: 1;
-  }
+  background: none;
+  border: none;
+  color: var(--text-light);
+  cursor: pointer;
+  font-size: 20px;
+  margin: 0;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  line-height: 1;
+}
 
-  .actions-toggle:hover,
-  .actions-toggle:focus {
-    background-color: var(--bg-button);
-    color: var(--accent);
-  }
+.actions-toggle:hover,
+.actions-toggle:focus {
+  background-color: var(--bg-button);
+  color: var(--accent);
+}
 
-  .actions-toggle:active {
-    transform: scale(0.95);
-  }
+.actions-toggle:active {
+  transform: scale(0.95);
+}
 .action-menu {
   position: absolute;
   top: 28px;
@@ -1154,11 +1154,16 @@ html.modal-open {
 .action-menu.hidden {
   display: none;
 }
-.details-toggle {
-  cursor: pointer;
-  color: var(--accent);
-  font-size: 12px;
-  margin-top: 4px;
+/* footer vessel action bar */
+.vessel-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.vessel-actions button {
+  flex: 1 1 auto;
 }
 .load-line {
   font-size: 13px;
@@ -1166,15 +1171,6 @@ html.modal-open {
 }
 .vessel-details.hidden {
   display: none;
-}
-.rename-icon {
-  cursor: pointer;
-  margin-left: 8px;
-  font-size: 16px;
-  color: var(--icon-muted);
-}
-.rename-icon:hover {
-  color: var(--accent);
 }
 .assign-icon, .unassign-icon {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- add primary action bar with Harvest, Move, and Offload buttons on vessel cards
- move secondary actions to ellipsis dropdown with shared menu manager and outside-click/escape handling
- style vessel actions bar and round ellipsis button for better accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a396b8d828832982a7772cdf4dcff7