### PR TITLE
Restyle vessel card actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
             <div class="vessel-badge"></div>
             <div class="vessel-header">
               <h3 class="vessel-name"><span class="name-text"></span></h3>
-              <button class="actions-toggle" aria-label="More vessel actions" title="More vessel actions" role="button" aria-haspopup="menu" aria-controls="" aria-expanded="false">⋮</button>
+              <span class="ellipsis-trigger" aria-label="More vessel actions" title="More vessel actions" role="button" aria-haspopup="menu" aria-controls="" aria-expanded="false" tabindex="0">…</span>
               <div class="action-menu hidden" role="menu">
                 <button class="rename-btn" role="menuitem">Rename</button>
                 <button class="upgrade-btn" role="menuitem">Upgrade</button>
@@ -203,9 +203,9 @@
             <div class="progressBar"><div class="progress vessel-progress"></div></div>
             <div class="stat load-line"><span class="vessel-load"></span> / <span class="vessel-capacity"></span> kg (<span class="load-percent"></span>%)</div>
             <div class="vessel-actions">
-              <button class="harvest-btn" id="btn-harvest" title="Harvest">Harvest</button>
-              <button class="move-btn" id="btn-move" title="Move">Move</button>
-              <button class="offload-btn" id="btn-offload" title="Offload">Offload</button>
+              <button class="icon-btn harvest-btn" aria-label="Harvest" title="Harvest"><img src="assets/vessel-icons/HarvestVessel.png" alt="" /></button>
+              <button class="icon-btn move-btn" aria-label="Move" title="Move"><img src="assets/vessel-icons/MoveVessel.png" alt="" /></button>
+              <button class="icon-btn offload-btn" aria-label="Offload" title="Offload"><img src="assets/vessel-icons/OffloadVessel.png" alt="" /></button>
             </div>
             <div class="vessel-details hidden">
               <div class="stat">Tier: <span class="vessel-tier"></span></div>

--- a/style.css
+++ b/style.css
@@ -1112,31 +1112,18 @@ html.modal-open {
   justify-content: space-between;
   gap: 4px;
 }
-.actions-toggle {
+.ellipsis-trigger {
   background: none;
-  border: none;
-  color: var(--text-light);
-  cursor: pointer;
-  font-size: 20px;
-  margin: 0;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
+  border: 0;
+  padding: 6px;
   line-height: 1;
+  cursor: pointer;
+  opacity: 0.9;
 }
 
-.actions-toggle:hover,
-.actions-toggle:focus {
-  background-color: var(--bg-button);
-  color: var(--accent);
-}
-
-.actions-toggle:active {
-  transform: scale(0.95);
+.ellipsis-trigger:hover,
+.ellipsis-trigger:focus {
+  opacity: 1;
 }
 .action-menu {
   position: absolute;
@@ -1157,13 +1144,41 @@ html.modal-open {
 /* footer vessel action bar */
 .vessel-actions {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
   margin-top: 6px;
 }
 
 .vessel-actions button {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+}
+
+.icon-btn {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.9;
+}
+
+.icon-btn img {
+  width: 26px;
+  height: 26px;
+}
+
+.icon-btn:hover,
+.icon-btn:focus {
+  opacity: 1;
+}
+
+.icon-btn[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.4;
 }
 .load-line {
   font-size: 13px;

--- a/ui.js
+++ b/ui.js
@@ -711,7 +711,7 @@ function renderVesselGrid(){
     offloadBtn.id = `btn-offload-${idx}`;
     offloadBtn.onclick = ()=>{ state.currentVesselIndex = idx; openSellModal(); };
 
-    const actionsToggle = card.querySelector('.actions-toggle');
+    const actionsToggle = card.querySelector('.ellipsis-trigger');
     const actionMenu = card.querySelector('.action-menu');
     actionMenu.id = `vessel-menu-${idx}`;
     actionsToggle.setAttribute('aria-controls', actionMenu.id);
@@ -719,11 +719,14 @@ function renderVesselGrid(){
       actionMenu.classList.add('hidden');
       actionsToggle.setAttribute('aria-expanded', 'false');
       menuManager.clear(closeMenu);
+      actionsToggle.focus();
     };
     const openMenu = ()=>{
       actionMenu.classList.remove('hidden');
       actionsToggle.setAttribute('aria-expanded', 'true');
       menuManager.register(actionsToggle, actionMenu, closeMenu);
+      const first = actionMenu.querySelector('[role="menuitem"]');
+      if(first) first.focus();
     };
     const hoverMq = window.matchMedia('(hover:hover)');
     if(hoverMq.matches){
@@ -751,8 +754,6 @@ function renderVesselGrid(){
       } else if(e.key === 'ArrowDown'){
         e.preventDefault();
         if(actionMenu.classList.contains('hidden')) openMenu();
-        const first = actionMenu.querySelector('[role="menuitem"]');
-        if(first) first.focus();
       }
     });
 
@@ -778,8 +779,11 @@ function renderVesselGrid(){
     };
     const busy = vessel.status !== 'idle';
     harvestBtn.disabled = busy;
+    harvestBtn.setAttribute('aria-disabled', busy ? 'true' : 'false');
     moveBtn.disabled = busy;
+    moveBtn.setAttribute('aria-disabled', busy ? 'true' : 'false');
     offloadBtn.disabled = busy;
+    offloadBtn.setAttribute('aria-disabled', busy ? 'true' : 'false');
     upBtn.disabled = busy;
     renameBtn.disabled = busy;
     sellVesselBtn.disabled = busy;
@@ -854,8 +858,11 @@ function updateVesselCards(){
     const sellVesselBtn2 = card.querySelector('.sell-vessel-btn');
     const busy2 = vessel.status !== 'idle';
     harvestBtn2.disabled = busy2;
+    harvestBtn2.setAttribute('aria-disabled', busy2 ? 'true' : 'false');
     moveBtn2.disabled = busy2;
+    moveBtn2.setAttribute('aria-disabled', busy2 ? 'true' : 'false');
     offloadBtn2.disabled = busy2;
+    offloadBtn2.setAttribute('aria-disabled', busy2 ? 'true' : 'false');
     upBtn2.disabled = busy2;
     if(renameBtn2) renameBtn2.disabled = busy2;
     if(sellVesselBtn2) sellVesselBtn2.disabled = busy2;


### PR DESCRIPTION
## Summary
- simplify vessel action menu with bare ellipsis trigger and outside/escape dismiss
- replace text action buttons with icon-only versions for harvest, move and offload
- add styling and aria-disabled support for new vessel action buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39e22261c8329a59a72c1d75a74ce