### PR TITLE
Refine vessel card actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
             <div class="vessel-badge"></div>
             <div class="vessel-header">
               <h3 class="vessel-name"><span class="name-text"></span></h3>
-              <span class="ellipsis-trigger" aria-label="More vessel actions" title="More vessel actions" role="button" aria-haspopup="menu" aria-controls="" aria-expanded="false" tabindex="0">…</span>
+              <button class="ellipsis-trigger" aria-label="More actions" aria-haspopup="menu" aria-expanded="false" aria-controls="">…</button>
               <div class="action-menu hidden" role="menu">
                 <button class="rename-btn" role="menuitem">Rename</button>
                 <button class="upgrade-btn" role="menuitem">Upgrade</button>
@@ -203,9 +203,9 @@
             <div class="progressBar"><div class="progress vessel-progress"></div></div>
             <div class="stat load-line"><span class="vessel-load"></span> / <span class="vessel-capacity"></span> kg (<span class="load-percent"></span>%)</div>
             <div class="vessel-actions">
-              <button class="icon-btn harvest-btn" aria-label="Harvest" title="Harvest"><img src="assets/vessel-icons/HarvestVessel.png" alt="" /></button>
-              <button class="icon-btn move-btn" aria-label="Move" title="Move"><img src="assets/vessel-icons/MoveVessel.png" alt="" /></button>
-              <button class="icon-btn offload-btn" aria-label="Offload" title="Offload"><img src="assets/vessel-icons/OffloadVessel.png" alt="" /></button>
+              <button class="icon-btn harvest-btn" aria-label="Harvest" title="Harvest"><img src="/assets/vessel-icons/HarvestVessel.png" alt=""></button>
+              <button class="icon-btn move-btn" aria-label="Move" title="Move"><img src="/assets/vessel-icons/MoveVessel.png" alt=""></button>
+              <button class="icon-btn offload-btn" aria-label="Offload" title="Offload"><img src="/assets/vessel-icons/OffloadVessel.png" alt=""></button>
             </div>
             <div class="vessel-details hidden">
               <div class="stat">Tier: <span class="vessel-tier"></span></div>

--- a/style.css
+++ b/style.css
@@ -804,8 +804,8 @@ html.modal-open {
   color: var(--text-muted);
   margin-bottom: 4px;
 }
-.penCard button,
-.vesselCard button {
+.penCard button:not(.icon-btn),
+.vesselCard button:not(.icon-btn) {
   display: block;
   width: 100%;
   margin-top: 4px;
@@ -817,8 +817,8 @@ html.modal-open {
   border-radius: 6px;
   cursor: pointer;
 }
-.penCard button:hover,
-.vesselCard button:hover {
+.penCard button:not(.icon-btn):hover,
+.vesselCard button:not(.icon-btn):hover {
   background-color: var(--accent);
   color: var(--bg-darker);
 }
@@ -830,8 +830,8 @@ html.modal-open {
   background-color: #d45c5c;
 }
 
-.penCard button:disabled,
-.vesselCard button:disabled {
+.penCard button:not(.icon-btn):disabled,
+.vesselCard button:not(.icon-btn):disabled {
   background-color: #555;
   cursor: not-allowed;
 }
@@ -1102,21 +1102,25 @@ html.modal-open {
   font-size: 18px;
   margin-bottom: 10px;
   color: var(--accent);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  text-align: center;
 }
 .vessel-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 4px;
 }
 .ellipsis-trigger {
+  position: absolute;
+  top: 10px;
+  right: 10px;
   background: none;
   border: 0;
   padding: 6px;
+  min-width: 32px;
+  min-height: 32px;
   line-height: 1;
+  font-size: 20px;
   cursor: pointer;
   opacity: 0.9;
 }
@@ -1124,11 +1128,13 @@ html.modal-open {
 .ellipsis-trigger:hover,
 .ellipsis-trigger:focus {
   opacity: 1;
+  outline: 2px solid var(--focus, rgba(255,255,255,.25));
+  outline-offset: 2px;
 }
 .action-menu {
   position: absolute;
-  top: 28px;
-  right: 4px;
+  top: 40px;
+  right: 10px;
   background: var(--bg-panel);
   padding: 6px;
   border-radius: 6px;
@@ -1136,7 +1142,7 @@ html.modal-open {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  z-index: 5;
+  z-index: 10;
 }
 .action-menu.hidden {
   display: none;
@@ -1145,8 +1151,9 @@ html.modal-open {
 .vessel-actions {
   display: flex;
   justify-content: center;
-  gap: 10px;
-  margin-top: 6px;
+  gap: 14px;
+  margin-top: 10px;
+  width: 100%;
 }
 
 .vessel-actions button {
@@ -1154,8 +1161,8 @@ html.modal-open {
 }
 
 .icon-btn {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1167,18 +1174,20 @@ html.modal-open {
 }
 
 .icon-btn img {
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
 }
 
 .icon-btn:hover,
 .icon-btn:focus {
   opacity: 1;
+  outline: 2px solid var(--focus, rgba(255,255,255,.25));
+  outline-offset: 3px;
 }
 
 .icon-btn[aria-disabled="true"] {
   pointer-events: none;
-  opacity: 0.4;
+  opacity: 0.35;
 }
 .load-line {
   font-size: 13px;

--- a/ui.js
+++ b/ui.js
@@ -728,33 +728,10 @@ function renderVesselGrid(){
       const first = actionMenu.querySelector('[role="menuitem"]');
       if(first) first.focus();
     };
-    const hoverMq = window.matchMedia('(hover:hover)');
-    if(hoverMq.matches){
-      let closeTimer;
-      const scheduleClose = ()=>{ closeTimer = setTimeout(closeMenu, 150); };
-      const cancelClose = ()=>{ clearTimeout(closeTimer); };
-      actionsToggle.addEventListener('mouseenter', openMenu);
-      actionsToggle.addEventListener('focusin', openMenu);
-      actionsToggle.addEventListener('mouseleave', scheduleClose);
-      actionsToggle.addEventListener('focusout', scheduleClose);
-      actionMenu.addEventListener('mouseenter', cancelClose);
-      actionMenu.addEventListener('mouseleave', scheduleClose);
-    } else {
-      actionsToggle.addEventListener('click', e=>{
-        e.stopPropagation();
-        if(actionMenu.classList.contains('hidden')) openMenu();
-        else closeMenu();
-      });
-    }
-    actionsToggle.addEventListener('keydown', e=>{
-      if(e.key === 'Enter' || e.key === ' '){
-        e.preventDefault();
-        if(actionMenu.classList.contains('hidden')) openMenu();
-        else closeMenu();
-      } else if(e.key === 'ArrowDown'){
-        e.preventDefault();
-        if(actionMenu.classList.contains('hidden')) openMenu();
-      }
+    actionsToggle.addEventListener('click', e=>{
+      e.stopPropagation();
+      if(actionMenu.classList.contains('hidden')) openMenu();
+      else closeMenu();
     });
 
     const renameBtn = card.querySelector('.rename-btn');


### PR DESCRIPTION
## Summary
- Style vessel action row as icon-only buttons with larger hit targets
- Add accessible ellipsis trigger and high z-index action menu
- Simplify menu logic to toggle on click and close reliably

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1f7e2a88329adba61752bf67a60