### PR TITLE
fix: restore vessel actions and menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
             <div class="vessel-badge"></div>
             <div class="vessel-header">
               <h3 class="vessel-name"><span class="name-text"></span></h3>
-              <button class="ellipsis-trigger" aria-label="More actions" aria-haspopup="menu" aria-expanded="false" aria-controls="">…</button>
+              <button class="ellipsis-trigger" aria-label="More actions" aria-haspopup="menu" aria-expanded="false" aria-controls="">⋮</button>
               <div class="action-menu hidden" role="menu">
                 <button class="rename-btn" role="menuitem">Rename</button>
                 <button class="upgrade-btn" role="menuitem">Upgrade</button>
@@ -203,9 +203,9 @@
             <div class="progressBar"><div class="progress vessel-progress"></div></div>
             <div class="stat load-line"><span class="vessel-load"></span> / <span class="vessel-capacity"></span> kg (<span class="load-percent"></span>%)</div>
             <div class="vessel-actions">
-              <button class="icon-btn harvest-btn" aria-label="Harvest" title="Harvest"><img src="/assets/vessel-icons/HarvestVessel.png" alt=""></button>
-              <button class="icon-btn move-btn" aria-label="Move" title="Move"><img src="/assets/vessel-icons/MoveVessel.png" alt=""></button>
-              <button class="icon-btn offload-btn" aria-label="Offload" title="Offload"><img src="/assets/vessel-icons/OffloadVessel.png" alt=""></button>
+              <button class="icon-btn harvest-btn" aria-label="Harvest" title="Harvest"><img src="assets/vessel-icons/HarvestVessel.png" alt=""></button>
+              <button class="icon-btn move-btn" aria-label="Move" title="Move"><img src="assets/vessel-icons/MoveVessel.png" alt=""></button>
+              <button class="icon-btn offload-btn" aria-label="Offload" title="Offload"><img src="assets/vessel-icons/OffloadVessel.png" alt=""></button>
             </div>
             <div class="vessel-details hidden">
               <div class="stat">Tier: <span class="vessel-tier"></span></div>

--- a/style.css
+++ b/style.css
@@ -1114,6 +1114,9 @@ html.modal-open {
   position: absolute;
   top: 10px;
   right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   border: 0;
   padding: 6px;
@@ -1123,6 +1126,7 @@ html.modal-open {
   font-size: 20px;
   cursor: pointer;
   opacity: 0.9;
+  margin: 0;
 }
 
 .ellipsis-trigger:hover,
@@ -1169,6 +1173,7 @@ html.modal-open {
   background: transparent;
   border: 0;
   padding: 0;
+  margin: 0;
   cursor: pointer;
   opacity: 0.9;
 }


### PR DESCRIPTION
## Summary
- restore vessel card action icons with proper spacing and PNG assets
- implement minimal vertical ellipsis trigger with accessible menu

## Testing
- `npm test`

Manual testing:
1. Load the app and open the Vessels section.
2. Confirm Harvest, Move, and Offload icons appear centered at the bottom of each vessel card and respect disabled states.
3. Click each icon to open the corresponding modal/dialog.
4. Use the vertical ellipsis; ensure the menu opens and closes on outside click, Esc, or menu item selection, and only one menu stays open.
5. Verify icons and menu do not overflow the card on small and large screens and no console errors appear.


------
https://chatgpt.com/codex/tasks/task_e_68a3a67144c88329ad3c162693f91b9c