### PR TITLE
add mobile debug nav toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,20 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="debugChip" style="position:fixed;top:8px;right:8px;z-index:10000;padding:6px 10px;border-radius:8px;border:1px solid #2a323a;background:#161b21;color:#e9eef4;display:none">
+    Debug
+  </button>
   <nav id="app-nav" class="sidebar">
     <button id="nav-toggle">☰</button>
-    <button data-view="Farm">Farm</button>
-    <button data-view="Vessels">Vessels</button>
-    <button data-view="Staff">Staff</button>
-    <button data-view="Market">Market</button>
-    <button data-view="Shipyard">Shipyard</button>
-    <button data-view="Finance">Finance</button>
-    <button data-view="Logbook">Logbook</button>
+    <div id="nav-links">
+      <button data-view="Farm">Farm</button>
+      <button data-view="Vessels">Vessels</button>
+      <button data-view="Staff">Staff</button>
+      <button data-view="Market">Market</button>
+      <button data-view="Shipyard">Shipyard</button>
+      <button data-view="Finance">Finance</button>
+      <button data-view="Logbook">Logbook</button>
+    </div>
   </nav>
   <main id="app-main">
     <section id="view-Farm" class="hidden"></section>
@@ -40,7 +45,7 @@
         </div>
       </div>
       <div class="top-bar-group" id="statusGroup">
-        <div><strong>Cash:</strong> $<span id="cashCount">0</span></div>
+        <div><strong id="cashLabel">Cash:</strong> $<span id="cashCount">0</span></div>
         <div>
           <strong>Date:</strong>
           <span id="dateDisplay">Spring 1, Year 1</span>

--- a/style.css
+++ b/style.css
@@ -2076,3 +2076,19 @@ html.modal-open {
     display: block;
   }
 }
+
+/* === DEBUG: reveal nav when enabled === */
+body.debug-nav #app-nav{ position:fixed; top:0; left:0; right:auto; z-index:9999; }
+body.debug-nav #nav-links{
+  display:grid !important; gap:8px; background:rgba(18,22,26,.98);
+  padding:12px; border-right:1px solid #20262d;
+}
+body.debug-nav #nav-links button{
+  all:unset; padding:10px 12px; border-radius:8px; background:#27313a;
+  color:#e9eef4; cursor:pointer; display:block;
+}
+body.debug-nav #nav-links button[aria-current="page"]{ background:#32404d; }
+@media (max-width:800px){
+  body.debug-nav #nav-links{ transform:none !important; }
+}
+body.debug-nav #app-main{ padding-top:64px; } /* prevent overlap on mobile */

--- a/ui.js
+++ b/ui.js
@@ -2297,3 +2297,37 @@ onBoot(()=>{
 
 window.addEventListener('pagehide', saveGame);
 window.addEventListener('beforeunload', saveGame);
+
+(function mobileDebugToggle(){
+  function toggleDebugNav(){
+    document.body.classList.toggle('debug-nav');
+    console.log('Debug nav:', document.body.classList.contains('debug-nav') ? 'ON' : 'OFF');
+  }
+
+  // 5-tap on Cash label
+  const cashEl = document.getElementById('cashLabel');
+  if (cashEl){
+    let taps = 0, timer = null;
+    cashEl.addEventListener('click', () => {
+      taps++;
+      clearTimeout(timer);
+      timer = setTimeout(()=>{ taps = 0; }, 3000);
+      if (taps >= 5){ toggleDebugNav(); taps = 0; }
+    });
+  } else {
+    // Fallback chip if Cash isn’t found
+    const chip = document.getElementById('debugChip');
+    if (chip){
+      chip.style.display = 'inline-block';
+      chip.addEventListener('click', toggleDebugNav);
+    }
+  }
+})();
+
+// Ensure router shows a default view after DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+  try {
+    const last = localStorage.getItem('aqe_view') || 'Farm';
+    if (window.AQE?.router?.show) window.AQE.router.show(last);
+  } catch(e){ console.error('Router init error', e); }
+});


### PR DESCRIPTION
## Summary
- add hidden Debug chip and Cash label identifier for tap-based nav toggle
- reveal navigation on mobile via debug-nav styles
- enable 5-tap or chip toggle and safe router init

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a522a1a87c832996bcb54f3fec4279