### PR TITLE
Add Close button for debug overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   </button>
   <nav id="app-nav" class="sidebar">
     <button id="nav-toggle">☰</button>
+    <button id="debugClose" aria-label="Close navigation" hidden>Close</button>
     <div id="nav-links">
       <button data-view="Farm">Farm</button>
       <button data-view="Vessels">Vessels</button>

--- a/style.css
+++ b/style.css
@@ -2155,3 +2155,23 @@ body.debug-nav .top-icon-menu {
 body.debug-nav #app-main {
   pointer-events: none;
 }
+
+/* Debug overlay: visible Close button */
+body.debug-nav #debugClose{
+  position: fixed;
+  top: 10px; right: 12px;
+  z-index: 10000;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid #2a323a;
+  background: #161b21;
+  color: #e9eef4;
+  font-weight: 600;
+  letter-spacing: .2px;
+  display: inline-block;
+}
+
+/* Ensure overlay elements accept taps when debug is on */
+body.debug-nav #app-nav,
+body.debug-nav #nav-links,
+body.debug-nav #debugClose{ pointer-events: auto; }

--- a/ui.js
+++ b/ui.js
@@ -2347,6 +2347,30 @@ window.addEventListener('beforeunload', saveGame);
   }
 })();
 
+(function wireDebugClose(){
+  const btn = document.getElementById('debugClose');
+  if (btn){
+    btn.addEventListener('click', () => {
+      // Prefer central setter if present, else toggle class
+      if (window.__AQE_setDebugNav){
+        window.__AQE_setDebugNav(false);
+      } else {
+        document.body.classList.remove('debug-nav');
+      }
+    });
+
+    // Show/hide based on debug state
+    const obs = new MutationObserver(() => {
+      if (document.body.classList.contains('debug-nav')) {
+        btn.removeAttribute('hidden');
+      } else {
+        btn.setAttribute('hidden','');
+      }
+    });
+    obs.observe(document.body, { attributes:true, attributeFilter:['class'] });
+  }
+})();
+
 // Ensure router shows a default view after DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
   try {


### PR DESCRIPTION
## Summary
- show Close button inside navigation when debug overlay active
- style Close button and enable pointer events for overlay elements
- wire Close button to hide the debug overlay

## Testing
- `npm test`
- Manual: tap Cash five times to open debug overlay, confirm Close button appears, and tap Close to hide overlay

------
https://chatgpt.com/codex/tasks/task_e_68a52967075483299839ae96a0d42077