### PR TITLE
Fix debug Close button visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -2169,10 +2169,11 @@ body.debug-nav #debugClose{
   color: #eee;
   font-size: 14px;
   font-weight: 600;
+  display: inline-block !important;
+  pointer-events: auto;
 
 }
 
 /* Ensure overlay elements accept taps when debug is on */
 body.debug-nav #app-nav,
-body.debug-nav #nav-links,
-body.debug-nav #debugClose{ pointer-events: auto; }
+body.debug-nav #nav-links{ pointer-events: auto; }


### PR DESCRIPTION
## Summary
- Ensure debug Close button is always visible and clickable in debug mode by forcing display and pointer events.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52f3f3afc8329b8277721374c828a