### PR TITLE
Add Vessels view scaffold and safe renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,11 @@
     </div>
   </footer>
 
+  <section id="view-Vessels" class="hidden">
+    <h2>Vessels</h2>
+    <p class="placeholder">Vessels page under construction.</p>
+  </section>
+
   <!-- Modals -->
     <div id="modal">
       <div id="modalContent">

--- a/ui.js
+++ b/ui.js
@@ -170,6 +170,30 @@ let logbookSection = 'milestones';
 
 // --- UPDATE UI ---
 function updateDisplay(){
+  const hash = window.location.hash;
+  const vesselView = document.getElementById('view-Vessels');
+  const mainView = document.getElementById('mainLayout');
+  const footerView = document.getElementById('bottomSection');
+
+  if(hash === '#view-Vessels'){
+    if(mainView) mainView.classList.add('hidden');
+    if(footerView) footerView.classList.add('hidden');
+    if(vesselView){
+      vesselView.classList.remove('hidden');
+      if(typeof window.renderVessels === 'function') window.renderVessels();
+      if(vesselView.children.length === 0){
+        const p = document.createElement('p');
+        p.className = 'placeholder';
+        p.textContent = 'Coming soon';
+        vesselView.appendChild(p);
+      }
+    }
+  } else {
+    if(mainView) mainView.classList.remove('hidden');
+    if(footerView) footerView.classList.remove('hidden');
+    if(vesselView) vesselView.classList.add('hidden');
+  }
+
   const site = state.sites[state.currentSiteIndex];
   const pen  = site.pens[state.currentPenIndex];
 
@@ -573,6 +597,12 @@ function renderVesselGrid(){
     }
     grid.appendChild(clone);
   });
+}
+
+if(!window.renderVessels){
+  window.renderVessels = function(){
+    if(typeof renderVesselGrid === 'function') renderVesselGrid();
+  };
 }
 
 function updateVesselCards(){


### PR DESCRIPTION
## Summary
- Add placeholder `#view-Vessels` section to prevent blank screen when navigating to Vessels view
- Call `renderVessels` from `updateDisplay` and toggle view visibility based on URL hash
- Provide global `renderVessels` stub that falls back to rendering vessel grid and injects placeholder if empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a54999156c8329af9e57f5ebd8d4e1