### PR TITLE
Add placeholder Vessels view and safe renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,10 @@
       </div>
     </div>
     </section>
-    <section id="view-Vessels" class="hidden"></section>
+    <section id="view-Vessels" class="hidden">
+      <h2>Vessels</h2>
+      <p class="placeholder">Vessels page under construction</p>
+    </section>
     <section id="view-Staff" class="hidden"></section>
     <section id="view-Market" class="hidden"></section>
     <section id="view-Shipyard" class="hidden"></section>

--- a/ui.js
+++ b/ui.js
@@ -420,8 +420,32 @@ window.updateDisplay = (function(){
     if(active === 'Staff')     safe(window.renderStaff);
     if(active === 'Shipyard')  safe(window.renderShipyard);
     if(active === 'Logbook')   safe(window.renderLogbook);
+
+    const section = document.getElementById(`view-${active}`);
+    if(section && section.innerHTML.trim() === ''){
+      const p = document.createElement('p');
+      p.className = 'placeholder';
+      p.textContent = 'Coming soon';
+      section.appendChild(p);
+    }
   };
 })();
+
+window.renderVessels = window.renderVessels || function(){
+  const section = document.getElementById('view-Vessels');
+  if(!section) return;
+  section.querySelectorAll('.placeholder').forEach(el => el.remove());
+  const grid = section.querySelector('#vesselGridContainer');
+  if(grid && typeof renderVesselGrid === 'function'){
+    renderVesselGrid();
+  }
+  if(section.children.length === 1){
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'Coming soon';
+    section.appendChild(p);
+  }
+};
 
 // harvest preview
 // license management


### PR DESCRIPTION
## Summary
- Scaffold Vessels view with heading and placeholder content so navigation isn't blank
- Add renderVessels stub and updateDisplay fallback to safely render the Vessels page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a54cf939c08329beffc35d590c8348