### PR TITLE
feat: add farm action badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,24 +117,48 @@
         <div class="farm-actions-section">
           <h3><button id="operations-toggle" class="action-toggle" aria-expanded="true" aria-controls="operations-list">Operations</button></h3>
           <div id="operations-list" class="actions-list">
-            <button onclick="toggleStatusPanel('feed')">Feed</button>
-            <button onclick="toggleStatusPanel('barge')">Barges/Vessels</button>
-            <button onclick="toggleStatusPanel('staff')">Staff</button>
+            <button id="action-feed" class="action-badge" aria-label="Feed" onclick="toggleStatusPanel('feed')">
+              <span class="badge-icon"><img src="assets/general-icons/bulkbag.png" alt=""><span id="feedActionBadge" class="badge-count"></span></span>
+              <span class="badge-label">Feed</span>
+            </button>
+            <button id="action-vessels" class="action-badge" aria-label="Barges and Vessels" onclick="AQE.router.show('Vessels')">
+              <span class="badge-icon"><img src="assets/general-icons/cagesystem.png" alt=""><span id="vesselActionBadge" class="badge-count"></span></span>
+              <span class="badge-label">Barges</span>
+            </button>
+            <button id="action-staff" class="action-badge" aria-label="Staff" onclick="AQE.router.show('Staff')">
+              <span class="badge-icon"><img src="assets/general-icons/farmer.png" alt=""><span id="staffActionBadge" class="badge-count"></span></span>
+              <span class="badge-label">Staff</span>
+            </button>
           </div>
         </div>
         <div class="farm-actions-section">
           <h3><button id="site-toggle" class="action-toggle" aria-expanded="true" aria-controls="site-list">Site Management</button></h3>
           <div id="site-list" class="actions-list">
-            <button onclick="openSiteManagement()">Licenses</button>
-            <button onclick="openSiteManagement()">Upgrades</button>
+            <button id="action-licenses" class="action-badge" aria-label="Licenses" onclick="openSiteManagement()">
+              <span class="badge-icon"><img src="assets/general-icons/siteactions.png" alt=""></span>
+              <span class="badge-label">Licenses</span>
+            </button>
+            <button id="action-upgrades" class="action-badge" aria-label="Upgrades" onclick="openSiteManagement()">
+              <span class="badge-icon"><img src="assets/general-icons/shipyard.png" alt=""></span>
+              <span class="badge-label">Upgrades</span>
+            </button>
           </div>
         </div>
         <div class="farm-actions-section">
           <h3><button id="tools-toggle" class="action-toggle" aria-expanded="true" aria-controls="tools-list">Tools</button></h3>
           <div id="tools-list" class="actions-list">
-            <button onclick="toggleDevTools()">Dev</button>
-            <button onclick="openSpeciesData()">Codex</button>
-            <button onclick="window.__AQE_setDebugNav && window.__AQE_setDebugNav(true)">Debug</button>
+            <button id="action-dev" class="action-badge" aria-label="Dev Tools" onclick="toggleDevTools()">
+              <span class="badge-icon"><img src="assets/general-icons/browser.png" alt=""></span>
+              <span class="badge-label">Dev</span>
+            </button>
+            <button id="action-codex" class="action-badge" aria-label="Codex" onclick="openSpeciesData()">
+              <span class="badge-icon"><img src="assets/general-icons/marketreports.png" alt=""></span>
+              <span class="badge-label">Codex</span>
+            </button>
+            <button id="action-debug" class="action-badge" aria-label="Debug" onclick="window.__AQE_setDebugNav && window.__AQE_setDebugNav(true)">
+              <span class="badge-icon"><img src="assets/general-icons/restock.png" alt=""></span>
+              <span class="badge-label">Debug</span>
+            </button>
           </div>
         </div>
       </aside>

--- a/style.css
+++ b/style.css
@@ -1692,13 +1692,81 @@ html.modal-open {
   color: inherit;
 }
 .actions-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 12px 8px;
   padding-left: 8px;
 }
 .actions-list[hidden] {
   display: none;
+}
+
+.action-badge {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+.action-badge[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action-badge:focus .badge-icon,
+.action-badge:hover .badge-icon {
+  box-shadow: 0 0 8px var(--accent);
+}
+
+.badge-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--bg-button);
+  color: var(--text-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  box-shadow: 0 0 4px var(--shadow-light);
+  transition: box-shadow 0.2s ease;
+}
+
+.badge-icon img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+}
+
+.badge-label {
+  font-size: 12px;
+}
+
+.badge-count {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background: var(--accent);
+  color: var(--text-dark);
+  border-radius: 10px;
+  padding: 1px 4px;
+  font-size: 10px;
+}
+
+.action-badge.locked .badge-icon img {
+  opacity: 0.3;
+}
+
+.action-badge.locked .badge-icon::after {
+  content: '\1f512';
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 @media (max-width: 700px) {
   #farm-view {

--- a/ui.js
+++ b/ui.js
@@ -278,6 +278,13 @@ function legacyUpdateDisplay(){
       state.tips.vesselUnlocked = true;
     }
   }
+  const vesselAction = document.getElementById('action-vessels');
+  if(vesselAction){
+    vesselAction.classList.toggle('locked', !shipyardUnlocked);
+    vesselAction.setAttribute('aria-disabled', String(!shipyardUnlocked));
+    if(!shipyardUnlocked) vesselAction.title = 'Unlocks after stocking your first pen.';
+    else vesselAction.removeAttribute('title');
+  }
   const penBtn = document.getElementById('buyPenBtn');
   const penReason = document.getElementById('penLockReason');
   const penUnlocked = state.milestones.firstHarvest && state.milestones.firstSale;
@@ -330,6 +337,16 @@ function legacyUpdateDisplay(){
       staffBadge.classList.remove('alert');
     }
   }
+  const feedActionBadge = document.getElementById('feedActionBadge');
+  if(feedActionBadge) feedActionBadge.textContent = `${totalFeed.toFixed(0)}/${totalFeedCap}kg`;
+  const vesselActionBadge = document.getElementById('vesselActionBadge');
+  if(vesselActionBadge){
+    const owned = state.vessels?.length || 0;
+    const limit = state.vesselLimit;
+    vesselActionBadge.textContent = limit ? `${owned}/${limit}` : String(owned);
+  }
+  const staffActionBadge = document.getElementById('staffActionBadge');
+  if(staffActionBadge) staffActionBadge.textContent = site.staff.length;
 
   // vessel grid
 


### PR DESCRIPTION
## Summary
- replace Farm action text buttons with circular icon badges
- display live feed, vessel, and staff counts on badges
- style badges with responsive grid and lock overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5506944008329b9df731496157480