### PR TITLE
feat: add in-page site management panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           <img id="siteActionToggle" src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-button" onclick="toggleSiteActions()" />
           <div id="siteActionMenu" class="hidden">
             <button onclick="buyNewSite()">+ New Site</button>
-            <button onclick="openSiteManagement()">Manage Site</button>
+            <button onclick="openSiteManagement(null, this)">Manage Site</button>
           </div>
         </div>
         <div class="mobile-action-wrapper" id="toolsActionGroup">
@@ -134,11 +134,11 @@
         <div class="farm-actions-section">
           <h3><button id="site-toggle" class="action-toggle" aria-expanded="true" aria-controls="site-list">Site Management</button></h3>
           <div id="site-list" class="actions-list">
-            <button id="action-licenses" class="action-badge" aria-label="Licenses" onclick="openSiteManagement()">
+            <button id="action-licenses" class="action-badge" aria-label="Licenses" onclick="openSiteManagement('licenses', this)">
               <span class="badge-icon"><img src="assets/general-icons/siteactions.png" alt=""></span>
               <span class="badge-label">Licenses</span>
             </button>
-            <button id="action-upgrades" class="action-badge" aria-label="Upgrades" onclick="openSiteManagement()">
+            <button id="action-upgrades" class="action-badge" aria-label="Upgrades" onclick="openSiteManagement('upgrades', this)">
               <span class="badge-icon"><img src="assets/general-icons/shipyard.png" alt=""></span>
               <span class="badge-label">Upgrades</span>
             </button>
@@ -163,6 +163,51 @@
         </div>
       </aside>
       <div id="farm-main">
+
+    <div id="siteManagementPanel" class="site-management-panel" aria-hidden="true">
+      <div class="site-mgmt-header">
+        <h2 id="siteMgmtHeader" tabindex="-1">Site Management – <span id="siteMgmtSiteName"></span></h2>
+        <button id="siteMgmtClose" aria-label="Close" onclick="closeSiteManagement()">×</button>
+      </div>
+      <div class="site-mgmt-tabs" role="tablist">
+        <button id="siteMgmtTab-licenses" role="tab" aria-selected="true" aria-controls="siteMgmtPane-licenses" onclick="switchSiteMgmtTab('licenses')">Licenses</button>
+        <button id="siteMgmtTab-upgrades" role="tab" aria-selected="false" aria-controls="siteMgmtPane-upgrades" onclick="switchSiteMgmtTab('upgrades')">Upgrades</button>
+        <button id="siteMgmtTab-settings" role="tab" aria-selected="false" aria-controls="siteMgmtPane-settings" onclick="switchSiteMgmtTab('settings')">Settings</button>
+      </div>
+      <div class="site-mgmt-content">
+        <div id="siteMgmtPane-licenses" class="site-mgmt-pane">
+          <div id="siteLicenses"></div>
+          <section id="licenseShop">
+            <div class="site-switcher">
+              <button id="licenseDropdownBtn" onclick="toggleLicenseList()">Buy License ⌄</button>
+              <div id="licenseDropdownList" class="site-list hidden"></div>
+            </div>
+          </section>
+        </div>
+        <div id="siteMgmtPane-upgrades" class="site-mgmt-pane hidden">
+          <div id="siteUpgrades" class="site-upgrade-grid">
+            <div class="site-upgrade-card">
+              <h4>Dock Upgrade</h4>
+              <p>Improves vessel turnaround speed.</p>
+              <button data-upgrade="dockUpgrade" disabled>Work in Progress</button>
+            </div>
+            <div class="site-upgrade-card">
+              <h4>Warehouse Expansion</h4>
+              <p>Increases passive storage or barge feed storage.</p>
+              <button data-upgrade="warehouseExpansion" disabled>Work in Progress</button>
+            </div>
+            <div class="site-upgrade-card">
+              <h4>Environmental Sensors</h4>
+              <p>Unlocks weather or seasonal UI in future.</p>
+              <button data-upgrade="envSensors" disabled>Work in Progress</button>
+            </div>
+          </div>
+        </div>
+        <div id="siteMgmtPane-settings" class="site-mgmt-pane hidden">
+          <p>Settings coming soon.</p>
+        </div>
+      </div>
+    </div>
 
     <div id="feedPanel" class="status-panel">
     <h2>Feed Management</h2>
@@ -455,6 +500,8 @@
       </div>
     </div>
 
+    <!-- Legacy Site Management Modal kept for reference -->
+    <!--
     <div id="siteManagementModal">
       <div id="siteManagementContent">
         <button class="close-report-btn" onclick="closeSiteManagement()">Back</button>
@@ -486,6 +533,7 @@
         </div>
       </div>
     </div>
+    -->
 
     <div id="bargeUpgradeModal">
       <div id="bargeUpgradeModalContent">

--- a/style.css
+++ b/style.css
@@ -610,6 +610,72 @@ html.modal-open {
   width: 340px;
 }
 
+/* In-page Site Management panel */
+.site-management-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100%;
+  max-width: 360px;
+  height: 100%;
+  background: var(--bg-panel);
+  box-shadow: 0 0 8px var(--shadow-medium);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 10;
+}
+
+.site-management-panel.open {
+  transform: translateX(0);
+}
+
+.site-mgmt-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px;
+  border-bottom: 1px solid var(--accent);
+}
+
+.site-mgmt-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 8px;
+}
+
+.site-mgmt-tabs [role="tab"] {
+  flex: 1;
+  background: var(--bg-button);
+  color: var(--text-light);
+  border: none;
+  padding: 6px;
+}
+
+.site-mgmt-tabs [aria-selected="true"] {
+  background: var(--accent);
+}
+
+.site-mgmt-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+}
+
+.site-mgmt-pane.hidden {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .site-management-panel {
+    position: fixed;
+    left: 0;
+    right: 0;
+    max-width: none;
+  }
+}
+
 #devModalContent h3 {
   margin-top: 16px;
   font-size: 14px;
@@ -1675,6 +1741,7 @@ html.modal-open {
 }
 #farm-main {
   flex: 1;
+  position: relative;
 }
 .farm-actions-section {
   margin-bottom: 12px;

--- a/ui.js
+++ b/ui.js
@@ -1995,7 +1995,7 @@ function openMarketReports(){
   openMarketReport();
 }
 
-function openSiteManagement(){
+function openSiteManagementModalLegacy(){
   const modal = document.getElementById('siteManagementModal');
   const nameEl = document.getElementById('siteManagementSiteName');
   if(nameEl) nameEl.innerText = state.sites[state.currentSiteIndex].name;
@@ -2007,10 +2007,66 @@ function openSiteManagement(){
   document.documentElement.style.overflow = 'hidden';
 }
 
-function closeSiteManagement(){
+function closeSiteManagementModalLegacy(){
   document.getElementById('siteManagementModal').classList.remove('visible');
   document.body.style.overflow = '';
   document.documentElement.style.overflow = '';
+}
+
+let siteMgmtTriggerEl = null;
+
+function openSiteManagement(tab = null, trigger = null){
+  const panel = document.getElementById('siteManagementPanel');
+  if(!panel) return;
+  siteMgmtTriggerEl = trigger || document.activeElement;
+  const nameEl = document.getElementById('siteMgmtSiteName');
+  if(nameEl) nameEl.innerText = state.sites[state.currentSiteIndex].name;
+  updateSiteLicenses();
+  updateLicenseDropdown();
+  updateSiteUpgrades();
+  panel.classList.add('open');
+  panel.setAttribute('aria-hidden','false');
+  switchSiteMgmtTab(tab || localStorage.getItem('siteMgmtTab') || 'licenses');
+  localStorage.setItem('siteMgmtOpen','true');
+  const header = document.getElementById('siteMgmtHeader');
+  header && header.focus();
+}
+
+function closeSiteManagement(){
+  const panel = document.getElementById('siteManagementPanel');
+  if(panel){
+    panel.classList.remove('open');
+    panel.setAttribute('aria-hidden','true');
+  }
+  localStorage.setItem('siteMgmtOpen','false');
+  if(siteMgmtTriggerEl){
+    siteMgmtTriggerEl.focus();
+    siteMgmtTriggerEl = null;
+  }
+}
+
+function switchSiteMgmtTab(tab){
+  const tabs = ['licenses','upgrades','settings'];
+  tabs.forEach(t => {
+    const btn = document.getElementById('siteMgmtTab-' + t);
+    const pane = document.getElementById('siteMgmtPane-' + t);
+    const selected = t === tab;
+    if(btn){
+      btn.setAttribute('aria-selected', String(selected));
+    }
+    if(pane){
+      pane.classList.toggle('hidden', !selected);
+    }
+  });
+  localStorage.setItem('siteMgmtTab', tab);
+}
+
+function initSiteManagementPanel(){
+  const storedTab = localStorage.getItem('siteMgmtTab') || 'licenses';
+  switchSiteMgmtTab(storedTab);
+  if(localStorage.getItem('siteMgmtOpen') === 'true'){
+    openSiteManagement(storedTab);
+  }
 }
 
 function openDevModal(){
@@ -2372,6 +2428,7 @@ function toggleStatusPanel(key){
   openMarketReports,
   openSiteManagement,
   closeSiteManagement,
+  switchSiteMgmtTab,
   updateSiteUpgrades,
   openDevModal,
   closeDevModal,
@@ -2407,6 +2464,7 @@ for (const key in ui){
     setupStatusTooltips();
     setupMapInteractions();
     initFarmActions();
+    initSiteManagementPanel();
   });
 
 window.addEventListener('pagehide', saveGame);


### PR DESCRIPTION
## Summary
- replace site management modal with a right-column panel that holds licenses, upgrades, and settings tabs
- persist panel visibility and active tab in localStorage with focus restoration
- keep legacy modal markup for back-compat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a55632f80083298bb52439c170a6e1