### PR TITLE
feat: streamline top bar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Aquaculture Empire</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="topbar-status-only">
   <button id="debugChip" style="position:fixed;top:8px;right:8px;z-index:10000;padding:6px 10px;border-radius:8px;border:1px solid #2a323a;background:#161b21;color:#e9eef4;display:none">
     Debug
   </button>
@@ -53,6 +53,7 @@
           <div id="siteDropdownList" class="site-list hidden"></div>
         </div>
       </div>
+      <strong id="gameTitle">Aquaculture Empire</strong>
       <div class="top-bar-group" id="statusGroup">
         <div><strong id="cashLabel">Cash:</strong> $<span id="cashCount">0</span></div>
         <div>
@@ -62,16 +63,16 @@
           <span id="playButton" class="time-btn" title="Resume" onclick="resumeTime()">▶️</span>
         </div>
       </div>
-      <div id="actionIconsWrapper">
+      <div id="actionIconsWrapper" class="topbar-actions">
         <div class="mobile-action-wrapper" id="siteActionGroup">
-          <img id="siteActionToggle" src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-button" onclick="toggleSiteActions()" />
+          <img id="siteActionToggle" src="assets/general-icons/siteactions.png" alt="Site Actions" class="icon-button" />
           <div id="siteActionMenu" class="hidden">
             <button onclick="buyNewSite()">+ New Site</button>
             <button onclick="openSiteManagement(null, this)">Manage Site</button>
           </div>
         </div>
         <div class="mobile-action-wrapper" id="toolsActionGroup">
-          <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" onclick="toggleMobileActions()" />
+          <img id="mobileActionToggle" src="assets/general-icons/browser.png" alt="Tools" class="icon-button" />
           <div id="mobileActionGroup" class="hidden">
             <button onclick="openMarketReport()">Market</button>
             <button id="shipyardBtn" onclick="openShipyard()">Shipyard</button><span id="shipyardLockReason" class="lock-reason"></span>
@@ -83,7 +84,7 @@
         </div>
         <div class="mobile-action-wrapper" id="bankActionGroup">
           <img id="bankActionToggle" src="assets/general-icons/bank.png"
-               alt="Bank" class="icon-button" onclick="toggleBankActions()" />
+               alt="Bank" class="icon-button" />
           <div id="bankActionMenu" class="hidden">
             <button onclick="openBank()">Bank</button>
             <button onclick="openMarketReports()">Market Reports</button>
@@ -91,18 +92,18 @@
           </div>
         </div>
       </div>
-      <div id="quickStatusBar">
-        <div id="feedStatusIcon" class="status-icon" onclick="toggleStatusPanel('feed')">
+      <div id="quickStatusBar" class="topbar-actions">
+        <div id="feedStatusIcon" class="status-icon">
           <img src="assets/general-icons/bulkbag.png" alt="Feed">
           <div class="status-label">Feed</div>
           <div class="status-badge" id="feedStatusBadge">0/0kg</div>
         </div>
-        <div id="bargeStatusIcon" class="status-icon" onclick="toggleStatusPanel('barge')">
+        <div id="bargeStatusIcon" class="status-icon">
           <img src="assets/general-icons/cagesystem.png" alt="Barge">
           <div class="status-label">Barge</div>
           <div class="status-badge" id="bargeStatusBadge"></div>
         </div>
-        <div id="staffStatusIcon" class="status-icon" onclick="toggleStatusPanel('staff')">
+        <div id="staffStatusIcon" class="status-icon">
           <img src="assets/general-icons/farmer.png" alt="Staff">
           <div class="status-label">Staff</div>
           <div class="status-badge" id="staffStatusBadge"></div>

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@
   --border: #444;
   --black: #000;
   --font-main: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
-  --header-height: 80px;
+  --header-height: 56px;
 }
 
 /* Global Styles */
@@ -1369,10 +1369,19 @@ body.panel-open {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 4px 12px;
   margin: 0 auto;
   max-width: 1200px;
   color: var(--text-light);
+}
+
+body.topbar-status-only .topbar-actions {
+  display: none;
+}
+
+#gameTitle {
+  font-size: 18px;
+  font-weight: bold;
 }
 
 @media (max-width: 500px) {
@@ -1407,7 +1416,7 @@ body.panel-open {
 .top-bar-group {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
 }
 
 .top-bar-group button {

--- a/ui.js
+++ b/ui.js
@@ -1105,6 +1105,7 @@ function setupMapInteractions(){
 
 // tooltip for quick status icons
 function setupStatusTooltips(){
+  if(document.body.classList.contains('topbar-status-only')) return;
   const tooltip = document.getElementById('statusTooltip');
   if(!tooltip) return;
 


### PR DESCRIPTION
## Summary
- simplify top bar to status-only and add game title
- hide deprecated top-bar action icons behind feature flag
- shrink header height and remove tooltip logic when icons disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a55fa1ab508329a44aee4f41e2d1f7