### PR TITLE
refactor: compact top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Aquaculture Empire</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="topbar-status-only">
+<body>
   <button id="debugChip" style="position:fixed;top:8px;right:8px;z-index:10000;padding:6px 10px;border-radius:8px;border:1px solid #2a323a;background:#161b21;color:#e9eef4;display:none">
     Debug
   </button>
@@ -55,12 +55,12 @@
       </div>
       <strong id="gameTitle">Aquaculture Empire</strong>
       <div class="top-bar-group" id="statusGroup">
-        <div><strong id="cashLabel">Cash:</strong> $<span id="cashCount">0</span></div>
+        <div><strong id="cashLabel">Cash:</strong> $<span id="cashCount" aria-live="polite">0</span></div>
         <div>
           <strong>Date:</strong>
-          <span id="dateDisplay">Spring 1, Year 1</span>
-          <span id="pauseButton" class="time-btn" title="Pause" onclick="pauseTime()">⏸️</span>
-          <span id="playButton" class="time-btn" title="Resume" onclick="resumeTime()">▶️</span>
+          <span id="dateDisplay" aria-live="polite">Spring 1, Year 1</span>
+          <button id="pauseButton" class="time-btn" title="Pause" aria-label="Pause" onclick="pauseTime()">⏸️</button>
+          <button id="playButton" class="time-btn" title="Resume" aria-label="Resume" onclick="resumeTime()">▶️</button>
         </div>
       </div>
         <div id="quickStatusBar" class="topbar-actions">

--- a/style.css
+++ b/style.css
@@ -1369,29 +1369,46 @@ body.panel-open {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   padding: 4px 12px;
   margin: 0 auto;
   max-width: 1200px;
   color: var(--text-light);
 }
 
-body.topbar-status-only .topbar-actions {
+.topbar-actions {
   display: none;
 }
 
 #gameTitle {
+  flex: 1;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 18px;
   font-weight: bold;
 }
 
-@media (max-width: 500px) {
+@media (max-width: 360px) {
   :root {
     --header-height: 48px;
   }
   #topBar {
-    flex-direction: column;
-    gap: 2px;
     padding: 2px 4px;
+  }
+  #gameTitle {
+    flex-basis: 100%;
+  }
+  #siteGroup,
+  #statusGroup {
+    flex-basis: 50%;
+  }
+  #siteGroup {
+    justify-content: flex-start;
+  }
+  #statusGroup {
+    justify-content: flex-end;
   }
   .top-bar-group {
     gap: 2px;
@@ -1431,9 +1448,19 @@ body.topbar-status-only .topbar-actions {
 }
 
 .time-btn {
-  cursor: pointer;
-  margin-left: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 0 0 4px;
   font-size: 16px;
+  cursor: pointer;
+  color: inherit;
+}
+
+.time-btn:hover,
+.time-btn:focus {
+  background: none;
+  color: inherit;
 }
 
 .top-bar-group button:hover {

--- a/ui.js
+++ b/ui.js
@@ -998,7 +998,8 @@ function setupMapInteractions(){
 
 // tooltip for quick status icons
 function setupStatusTooltips(){
-  if(document.body.classList.contains('topbar-status-only')) return;
+  const actions = document.querySelector('.topbar-actions');
+  if(!actions || getComputedStyle(actions).display === 'none') return;
   const tooltip = document.getElementById('statusTooltip');
   if(!tooltip) return;
 


### PR DESCRIPTION
## Summary
- hide legacy top bar actions and keep only site picker, title and status strip
- center game title and make pause/resume buttons accessible
- adjust layout for very small screens and drop unused icon listeners

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60dfb5db88329ae42879dc6b1973c