### PR TITLE
refine: compact status-only top bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@
   --border: #444;
   --black: #000;
   --font-main: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
-  --header-height: 56px;
+  --header-height: 52px;
 }
 
 /* Global Styles */
@@ -1361,6 +1361,7 @@ body.panel-open {
   right: 0;
   min-height: var(--header-height);
   background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
   box-shadow: 0 2px 6px var(--shadow-medium);
   z-index: 100;
 }
@@ -1370,7 +1371,7 @@ body.panel-open {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  padding: 4px 12px;
+  padding: 2px 12px;
   margin: 0 auto;
   max-width: 1200px;
   color: var(--text-light);
@@ -1378,6 +1379,7 @@ body.panel-open {
 
 .topbar-actions {
   display: none;
+  pointer-events: none;
 }
 
 #gameTitle {

--- a/ui.js
+++ b/ui.js
@@ -2372,7 +2372,10 @@ for (const key in ui){
   onBoot(()=>{
     adjustHeaderPadding();
     updateDisplay();
-    setupStatusTooltips();
+    const actions = document.querySelector('.topbar-actions');
+    if(actions && getComputedStyle(actions).display !== 'none'){
+      setupStatusTooltips();
+    }
     setupMapInteractions();
     initFarmActions();
     initSiteManagementPanel();


### PR DESCRIPTION
## Summary
- shrink header height and padding for a tighter top bar
- hide legacy top bar actions and block interaction
- only attach tooltip handlers when action icons are visible

## Testing
- `npm test`

## Manual Testing
- Open `index.html` in a browser.
- Verify top bar shows only site selector, title, cash, date/season, and pause/play.
- Scroll page and confirm top bar stays fixed with a divider and no overlap.
- Resize window below 360px and ensure items wrap without horizontal scroll.
- Confirm no Feed/Barges/Staff icons appear and clicking the top bar triggers no extra actions.


------
https://chatgpt.com/codex/tasks/task_e_68a6113baa8083298ec6368500907114