### PR TITLE
feat: remove top bar action icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,23 +57,6 @@
           </div>
         </div>
       </div>
-      <div id="quickStatusBar">
-        <div id="feedStatusIcon" class="status-icon" onclick="toggleStatusPanel('feed')">
-          <img src="assets/general-icons/bulkbag.png" alt="Feed">
-          <div class="status-label">Feed</div>
-          <div class="status-badge" id="feedStatusBadge">0/0kg</div>
-        </div>
-        <div id="bargeStatusIcon" class="status-icon" onclick="toggleStatusPanel('barge')">
-          <img src="assets/general-icons/cagesystem.png" alt="Barge">
-          <div class="status-label">Barge</div>
-          <div class="status-badge" id="bargeStatusBadge"></div>
-        </div>
-        <div id="staffStatusIcon" class="status-icon" onclick="toggleStatusPanel('staff')">
-          <img src="assets/general-icons/farmer.png" alt="Staff">
-          <div class="status-label">Staff</div>
-          <div class="status-badge" id="staffStatusBadge"></div>
-        </div>
-      </div>
     </div>
     </div>
   </header>
@@ -437,7 +420,6 @@
       <!-- Market tables and future graph placeholder will be injected into this container -->
       <div id="marketReportContent" class="market-report"></div>
       </div>
-    <div id="statusTooltip" class="status-tooltip" role="tooltip"></div>
     <div id="toastContainer"></div>
     <script type="module" src="script.js"></script>
   <script data-goatcounter="https://rwzephyr.goatcounter.com/count"

--- a/script.js
+++ b/script.js
@@ -22,7 +22,6 @@ document.addEventListener('DOMContentLoaded', () => {
   actions.loadGame();
   initMilestones();
   ui.updateDisplay();
-  ui.setupStatusTooltips();
   ui.setupMapInteractions();
   if(state.lastOfflineInfo){
     const days = state.lastOfflineInfo.daysPassed;

--- a/style.css
+++ b/style.css
@@ -926,42 +926,6 @@ html.modal-open {
   position: relative;
 }
 
-/* Status tooltip for quick icons */
-.status-tooltip {
-  position: fixed;
-  pointer-events: none;
-  background: var(--bg-darker);
-  color: var(--text-light);
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  white-space: nowrap;
-  opacity: 0;
-  transform: translate(-50%, -4px);
-  transition: opacity 0.15s ease;
-  z-index: 20;
-}
-
-.status-tooltip.visible {
-  opacity: 1;
-}
-
-.status-tooltip::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 6px solid transparent;
-  border-top-color: var(--bg-darker);
-  top: 100%;
-}
-
-.status-tooltip.below::after {
-  border-top-color: transparent;
-  border-bottom-color: var(--bg-darker);
-  top: auto;
-  bottom: 100%;
-}
 .status-harvesting { border-left: 6px solid #2ecc71; }
 .status-idle { border-left: 6px solid #3498db; }
 .status-delivering { border-left: 6px solid #e67e22; }
@@ -1460,60 +1424,6 @@ html.modal-open {
   color: var(--bg-darker);
 }
 
-/* Quick Status Bar */
-#quickStatusBar {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  padding: 8px 0;
-}
-
-.status-icon {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  background: var(--bg-button);
-  color: var(--text-light);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  cursor: pointer;
-  box-shadow: 0 0 4px var(--shadow-light);
-  transition: box-shadow 0.2s ease;
-}
-
-.status-icon img {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
-  margin-bottom: 2px;
-}
-
-.status-label {
-  font-size: 12px;
-}
-
-.status-badge {
-  position: absolute;
-  bottom: 4px;
-  right: 4px;
-  background: var(--accent);
-  color: var(--text-dark);
-  border-radius: 10px;
-  padding: 1px 4px;
-  font-size: 10px;
-}
-
-.status-badge.alert {
-  background: #e74c3c;
-  color: #fff;
-}
-
-.status-icon.active {
-  box-shadow: 0 0 8px var(--accent);
-}
 
 .status-panel {
   max-width: 960px;

--- a/ui.js
+++ b/ui.js
@@ -239,22 +239,6 @@ function updateDisplay(){
   if(totalFeedEl) totalFeedEl.innerText = totalFeed.toFixed(1);
   const totalFeedCapEl = document.getElementById('totalFeedCapacity');
   if(totalFeedCapEl) totalFeedCapEl.innerText = totalFeedCap;
-  const feedBadge = document.getElementById('feedStatusBadge');
-  if(feedBadge) feedBadge.textContent = `${totalFeed.toFixed(0)}/${totalFeedCap}kg`;
-  const bargeBadge = document.getElementById('bargeStatusBadge');
-  if(bargeBadge) bargeBadge.textContent = `${site.pens.filter(p=>p.feeder && p.bargeIndex===state.currentBargeIndex).length}/${barge.feederLimit}`;
-  const staffBadge = document.getElementById('staffStatusBadge');
-  const unassigned = site.staff.filter(s=>!s.role).length;
-  if(staffBadge){
-    if(unassigned>0){
-      staffBadge.textContent = `Idle:${unassigned}`;
-      staffBadge.classList.add('alert');
-    } else {
-      staffBadge.textContent = site.staff.length;
-      staffBadge.classList.remove('alert');
-    }
-  }
-
   // vessel grid
 
   // staff card info
@@ -786,85 +770,6 @@ function setupMapInteractions(){
 }
 
 // tooltip for quick status icons
-function setupStatusTooltips(){
-  const tooltip = document.getElementById('statusTooltip');
-  if(!tooltip) return;
-
-  const getInfo = {
-    feedStatusIcon(){
-      const site = state.sites[state.currentSiteIndex];
-      const total = site.barges.reduce((t,b)=>t+b.feed,0);
-      const cap = site.barges.reduce((t,b)=>t+b.feedCapacity,0);
-      return total >= cap ? 'Feed silos full' : `Feed: ${total.toFixed(0)}/${cap} kg`;
-    },
-    bargeStatusIcon(){
-      const site = state.sites[state.currentSiteIndex];
-      const barge = site.barges[state.currentBargeIndex];
-      const feeders = site.pens.filter(p=>p.feeder && p.bargeIndex===state.currentBargeIndex).length;
-      return feeders >= barge.feederLimit ? 'Feeder capacity full' : `${feeders}/${barge.feederLimit} feeders in use`;
-    },
-    staffStatusIcon(){
-      const site = state.sites[state.currentSiteIndex];
-      const unassigned = site.staff.filter(s=>!s.role).length;
-      if(unassigned>0) return `${unassigned} unassigned workers`;
-      const cap = site.barges.reduce((t,b)=>t+b.staffCapacity,0);
-      return `${site.staff.length}/${cap} staff`;
-    }
-  };
-
-  const attach = id => {
-    const icon = document.getElementById(id);
-    if(!icon) return;
-    let pressTimer;
-    let autoHide;
-    const show = () => {
-      tooltip.textContent = getInfo[id]();
-      tooltip.classList.add('visible');
-      tooltip.classList.remove('below');
-      const rect = icon.getBoundingClientRect();
-      tooltip.style.left = `${rect.left + rect.width/2}px`;
-      tooltip.style.top = `${rect.top - 8}px`;
-      requestAnimationFrame(()=>{
-        const tRect = tooltip.getBoundingClientRect();
-        let top = rect.top - tRect.height - 8;
-        let below = false;
-        if(window.innerWidth <= 700){
-          top = rect.bottom + 8;
-          below = true;
-        }
-        if(top < 4){ top = rect.bottom + 8; below = true; }
-        if(top + tRect.height > window.innerHeight){ top = rect.top - tRect.height - 8; below = false; }
-        tooltip.style.top = `${top}px`;
-        if(below) tooltip.classList.add('below'); else tooltip.classList.remove('below');
-        const left = Math.min(window.innerWidth - tRect.width/2 - 4, Math.max(tRect.width/2 + 4, rect.left + rect.width/2));
-        tooltip.style.left = `${left}px`;
-      });
-    };
-    const hide = () => {
-      tooltip.classList.remove('visible');
-    };
-    icon.addEventListener('mouseenter', show);
-    icon.addEventListener('mouseleave', hide);
-    icon.addEventListener('focus', show);
-    icon.addEventListener('blur', hide);
-    icon.addEventListener('touchstart', () => {
-      pressTimer = setTimeout(()=>{ show(); autoHide=setTimeout(hide,1500); }, 500);
-    });
-    icon.addEventListener('touchend', () => {
-      clearTimeout(pressTimer);
-    });
-    icon.addEventListener('touchcancel', () => {
-      clearTimeout(pressTimer);
-      clearTimeout(autoHide);
-      hide();
-    });
-  };
-
-  ['feedStatusIcon','bargeStatusIcon','staffStatusIcon'].forEach(attach);
-  window.addEventListener('scroll', () => tooltip.classList.remove('visible'));
-  window.addEventListener('resize', () => tooltip.classList.remove('visible'));
-}
-
 // --- MODALS ---
 function openModal(msg){
   const bargeModal = document.getElementById('bargeUpgradeModal');
@@ -1795,7 +1700,6 @@ export {
   renderVesselGrid,
   renderMap,
   setupMapInteractions,
-  setupStatusTooltips,
   openModal,
   closeModal,
   openRestockModal,


### PR DESCRIPTION
## Summary
- strip feed, barge, and staff quick-action icons from the top bar
- drop unused status-icon styles and tooltip logic
- keep initialization lean by removing unused status tooltip setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63b290ec88329b17d779bad79c644