### PR TITLE
remove action icons from top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,23 +63,6 @@
           <button id="playButton" class="time-btn" title="Resume" aria-label="Resume" onclick="resumeTime()">▶️</button>
         </div>
       </div>
-        <div id="quickStatusBar" class="topbar-actions">
-        <div id="feedStatusIcon" class="status-icon">
-          <img src="assets/general-icons/bulkbag.png" alt="Feed">
-          <div class="status-label">Feed</div>
-          <div class="status-badge" id="feedStatusBadge">0/0kg</div>
-        </div>
-        <div id="bargeStatusIcon" class="status-icon">
-          <img src="assets/general-icons/cagesystem.png" alt="Barge">
-          <div class="status-label">Barge</div>
-          <div class="status-badge" id="bargeStatusBadge"></div>
-        </div>
-        <div id="staffStatusIcon" class="status-icon">
-          <img src="assets/general-icons/farmer.png" alt="Staff">
-          <div class="status-label">Staff</div>
-          <div class="status-badge" id="staffStatusBadge"></div>
-        </div>
-      </div>
     </div>
     </div>
     </header>
@@ -577,7 +560,6 @@
       <!-- Market tables and future graph placeholder will be injected into this container -->
       <div id="marketReportContent" class="market-report"></div>
       </div>
-    <div id="statusTooltip" class="status-tooltip" role="tooltip"></div>
     <div id="onboardingChecklist" class="onboarding-card hidden"></div>
     <div id="toastContainer"></div>
   </main>

--- a/style.css
+++ b/style.css
@@ -947,6 +947,17 @@ body.panel-open {
   object-fit: contain;
 }
 
+.pen-locked {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background: var(--accent);
+  color: var(--text-dark);
+  border-radius: 10px;
+  padding: 1px 4px;
+  font-size: 10px;
+}
+
 .vessel-badge {
   /* notification-style overlay */
   width: 40px;
@@ -1064,43 +1075,6 @@ body.panel-open {
   box-shadow: 0 0 4px var(--shadow-light);
   transition: transform 0.2s, box-shadow 0.2s;
   position: relative;
-}
-
-/* Status tooltip for quick icons */
-.status-tooltip {
-  position: fixed;
-  pointer-events: none;
-  background: var(--bg-darker);
-  color: var(--text-light);
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  white-space: nowrap;
-  opacity: 0;
-  transform: translate(-50%, -4px);
-  transition: opacity 0.15s ease;
-  z-index: 20;
-}
-
-.status-tooltip.visible {
-  opacity: 1;
-}
-
-.status-tooltip::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 6px solid transparent;
-  border-top-color: var(--bg-darker);
-  top: 100%;
-}
-
-.status-tooltip.below::after {
-  border-top-color: transparent;
-  border-bottom-color: var(--bg-darker);
-  top: auto;
-  bottom: 100%;
 }
 .status-harvesting,
 .status-idle,
@@ -1377,11 +1351,6 @@ body.panel-open {
   color: var(--text-light);
 }
 
-.topbar-actions {
-  display: none;
-  pointer-events: none;
-}
-
 #gameTitle {
   flex: 1;
   text-align: center;
@@ -1563,61 +1532,6 @@ body.panel-open {
 .icon-menu div:hover {
   background-color: var(--accent);
   color: var(--bg-darker);
-}
-
-/* Quick Status Bar */
-#quickStatusBar {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  padding: 8px 0;
-}
-
-.status-icon {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  background: var(--bg-button);
-  color: var(--text-light);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  cursor: pointer;
-  box-shadow: 0 0 4px var(--shadow-light);
-  transition: box-shadow 0.2s ease;
-}
-
-.status-icon img {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
-  margin-bottom: 2px;
-}
-
-.status-label {
-  font-size: 12px;
-}
-
-.status-badge {
-  position: absolute;
-  bottom: 4px;
-  right: 4px;
-  background: var(--accent);
-  color: var(--text-dark);
-  border-radius: 10px;
-  padding: 1px 4px;
-  font-size: 10px;
-}
-
-.status-badge.alert {
-  background: #e74c3c;
-  color: #fff;
-}
-
-.status-icon.active {
-  box-shadow: 0 0 8px var(--accent);
 }
 
 .status-panel {

--- a/ui.js
+++ b/ui.js
@@ -575,7 +575,7 @@ function renderPenGrid(site){
     card.appendChild(badge);
 
     const lockBadge = document.createElement('div');
-    lockBadge.className = 'status-badge pen-locked';
+    lockBadge.className = 'pen-locked';
     lockBadge.title = 'Locked during harvest';
     lockBadge.textContent = 'Locked';
     if(!pen.locked) lockBadge.style.display = 'none';
@@ -629,7 +629,7 @@ function updatePenCards(site){
     let lockBadge = card.querySelector('.pen-locked');
     if(!lockBadge){
       lockBadge = document.createElement('div');
-      lockBadge.className = 'status-badge pen-locked';
+      lockBadge.className = 'pen-locked';
       lockBadge.title = 'Locked during harvest';
       lockBadge.textContent = 'Locked';
       card.appendChild(lockBadge);
@@ -994,88 +994,6 @@ function setupMapInteractions(){
   canvas.addEventListener('click', handle);
   canvas.addEventListener('touchstart', handle);
   canvas.addEventListener('mouseleave', ()=>{ tooltip.style.display='none'; });
-}
-
-// tooltip for quick status icons
-function setupStatusTooltips(){
-  const actions = document.querySelector('.topbar-actions');
-  if(!actions || getComputedStyle(actions).display === 'none') return;
-  const tooltip = document.getElementById('statusTooltip');
-  if(!tooltip) return;
-
-  const getInfo = {
-    feedStatusIcon(){
-      const site = state.sites[state.currentSiteIndex];
-      const total = site.barges.reduce((t,b)=>t+b.feed,0);
-      const cap = site.barges.reduce((t,b)=>t+b.feedCapacity,0);
-      return total >= cap ? 'Feed silos full' : `Feed: ${total.toFixed(0)}/${cap} kg`;
-    },
-    bargeStatusIcon(){
-      const site = state.sites[state.currentSiteIndex];
-      const barge = site.barges[state.currentBargeIndex];
-      const feeders = site.pens.filter(p=>p.feeder && p.bargeIndex===state.currentBargeIndex).length;
-      return feeders >= barge.feederLimit ? 'Feeder capacity full' : `${feeders}/${barge.feederLimit} feeders in use`;
-    },
-    staffStatusIcon(){
-      const site = state.sites[state.currentSiteIndex];
-      const unassigned = site.staff.filter(s=>!s.role).length;
-      if(unassigned>0) return `${unassigned} unassigned workers`;
-      const cap = site.barges.reduce((t,b)=>t+b.staffCapacity,0);
-      return `${site.staff.length}/${cap} staff`;
-    }
-  };
-
-  const attach = id => {
-    const icon = document.getElementById(id);
-    if(!icon) return;
-    let pressTimer;
-    let autoHide;
-    const show = () => {
-      tooltip.textContent = getInfo[id]();
-      tooltip.classList.add('visible');
-      tooltip.classList.remove('below');
-      const rect = icon.getBoundingClientRect();
-      tooltip.style.left = `${rect.left + rect.width/2}px`;
-      tooltip.style.top = `${rect.top - 8}px`;
-      requestAnimationFrame(()=>{
-        const tRect = tooltip.getBoundingClientRect();
-        let top = rect.top - tRect.height - 8;
-        let below = false;
-        if(window.innerWidth <= 700){
-          top = rect.bottom + 8;
-          below = true;
-        }
-        if(top < 4){ top = rect.bottom + 8; below = true; }
-        if(top + tRect.height > window.innerHeight){ top = rect.top - tRect.height - 8; below = false; }
-        tooltip.style.top = `${top}px`;
-        if(below) tooltip.classList.add('below'); else tooltip.classList.remove('below');
-        const left = Math.min(window.innerWidth - tRect.width/2 - 4, Math.max(tRect.width/2 + 4, rect.left + rect.width/2));
-        tooltip.style.left = `${left}px`;
-      });
-    };
-    const hide = () => {
-      tooltip.classList.remove('visible');
-    };
-    icon.addEventListener('mouseenter', show);
-    icon.addEventListener('mouseleave', hide);
-    icon.addEventListener('focus', show);
-    icon.addEventListener('blur', hide);
-    icon.addEventListener('touchstart', () => {
-      pressTimer = setTimeout(()=>{ show(); autoHide=setTimeout(hide,1500); }, 500);
-    });
-    icon.addEventListener('touchend', () => {
-      clearTimeout(pressTimer);
-    });
-    icon.addEventListener('touchcancel', () => {
-      clearTimeout(pressTimer);
-      clearTimeout(autoHide);
-      hide();
-    });
-  };
-
-  ['feedStatusIcon','bargeStatusIcon','staffStatusIcon'].forEach(attach);
-  window.addEventListener('scroll', () => tooltip.classList.remove('visible'));
-  window.addEventListener('resize', () => tooltip.classList.remove('visible'));
 }
 
 // --- MODALS ---
@@ -2315,7 +2233,6 @@ function toggleStatusPanel(key){
   renderVesselGrid,
   renderMap,
   setupMapInteractions,
-  setupStatusTooltips,
   closeModal,
   openRestockModal,
   closeRestockModal,
@@ -2372,10 +2289,6 @@ for (const key in ui){
   onBoot(()=>{
     adjustHeaderPadding();
     updateDisplay();
-    const actions = document.querySelector('.topbar-actions');
-    if(actions && getComputedStyle(actions).display !== 'none'){
-      setupStatusTooltips();
-    }
     setupMapInteractions();
     initFarmActions();
     initSiteManagementPanel();


### PR DESCRIPTION
## Summary
- drop Feed/Barge/Staff icons from the sticky top bar
- prune tooltip logic and quick-status styles tied to those icons
- add `pen-locked` badge style to maintain pen overlays

## Testing
- `npm test`
- Manual: load game, ensure top bar shows only site selector, title, cash, date, and pause/play. Feed, Barges, and Staff remain accessible via Farm actions and console shows no errors.


------
https://chatgpt.com/codex/tasks/task_e_68a64ee3860c8329844d38f9a241e7e6